### PR TITLE
Used stricter Clippy and `fmt` to combine imports

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Thank you for your interest in contributing!
+
+## Issues
+
+For bug reports, feature requests, improvements, or other suggestions, please open an issue.
+
+When creating an issue, include:
+- A short description of the problem or proposal
+- Steps to reproduce (if applicable)
+- Relevant logs, screenshots, or examples when possible
+
+## Pull Requests
+
+To contribute code or documentation:
+
+1. [Fork](https://docs.github.com/articles/fork-a-repo) the repository
+2. Create a new branch for your changes
+3. Make and test your changes
+4. Submit a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) with a clear description of the updates
+
+Please keep pull requests focused and reasonably scoped.

--- a/src/arxiv2wikidata.rs
+++ b/src/arxiv2wikidata.rs
@@ -1,10 +1,12 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
-use async_trait::async_trait;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+
 use self::identifiers::{GenericWorkIdentifier, GenericWorkType, IdProp};
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter, *,
+};
 
 pub struct Arxiv2Wikidata {
     author_cache: HashMap<String, String>,
@@ -47,11 +49,10 @@ impl Arxiv2Wikidata {
                     && !id[pos + 1..].is_empty() =>
             {
                 id[..pos].to_string()
-            }
+            },
             _ => id.to_string(),
         }
     }
-
 }
 
 #[async_trait(?Send)]
@@ -90,10 +91,8 @@ impl ScientificPublicationAdapter for Arxiv2Wikidata {
         let futures: Vec<_> = arxiv_ids
             .iter()
             .map(|arxiv_id| {
-                let query = arxiv::ArxivQueryBuilder::new()
-                    .id_list(arxiv_id)
-                    .max_results(1)
-                    .build();
+                let query =
+                    arxiv::ArxivQueryBuilder::new().id_list(arxiv_id).max_results(1).build();
                 arxiv::fetch_arxivs(query)
             })
             .collect();
@@ -121,10 +120,7 @@ impl ScientificPublicationAdapter for Arxiv2Wikidata {
         if self.work_cache.contains_key(publication_id) {
             return Some(publication_id.to_string());
         }
-        let query = arxiv::ArxivQueryBuilder::new()
-            .id_list(publication_id)
-            .max_results(1)
-            .build();
+        let query = arxiv::ArxivQueryBuilder::new().id_list(publication_id).max_results(1).build();
         let results = arxiv::fetch_arxivs(query).await.ok()?;
         let arxiv = results.into_iter().next()?;
         let arxiv_id = Self::extract_arxiv_id(&arxiv.id);
@@ -136,7 +132,7 @@ impl ScientificPublicationAdapter for Arxiv2Wikidata {
         match self.get_cached_publication_from_id(publication_id) {
             Some(arxiv) if !arxiv.title.is_empty() => {
                 vec![LocaleString::new("en", &arxiv.title)]
-            }
+            },
             _ => vec![],
         }
     }
@@ -223,7 +219,10 @@ mod tests {
             crate::scientific_publication_adapter::parse_date("2023-06"),
             Some((2023, Some(6), None))
         );
-        assert_eq!(crate::scientific_publication_adapter::parse_date("2023"), Some((2023, None, None)));
+        assert_eq!(
+            crate::scientific_publication_adapter::parse_date("2023"),
+            Some((2023, None, None))
+        );
     }
 
     #[test]
@@ -237,12 +236,7 @@ mod tests {
         let mut adapter = Arxiv2Wikidata::new();
         adapter.work_cache.insert(
             "2301.12345".to_string(),
-            make_arxiv(
-                "2301.12345",
-                "Test Paper Title",
-                vec![],
-                "2023-01-15T00:00:00Z",
-            ),
+            make_arxiv("2301.12345", "Test Paper Title", vec![], "2023-01-15T00:00:00Z"),
         );
         let titles = adapter.get_work_titles("2301.12345");
         assert_eq!(titles.len(), 1);
@@ -273,10 +267,7 @@ mod tests {
             "2301.12345".to_string(),
             make_arxiv("2301.12345", "Title", vec![], "2023-01-15T00:00:00Z"),
         );
-        assert_eq!(
-            adapter.get_publication_date("2301.12345"),
-            Some((2023, Some(1), Some(15)))
-        );
+        assert_eq!(adapter.get_publication_date("2301.12345"), Some((2023, Some(1), Some(15))));
     }
 
     #[tokio::test]

--- a/src/author_name_string.rs
+++ b/src/author_name_string.rs
@@ -1,13 +1,15 @@
-use crate::wikidata_interaction::WikidataInteraction;
-use crate::wikidata_papers::WikidataPapers;
-use crate::{generic_author_info::GenericAuthorInfo, wikidata_string_cache::WikidataStringCache};
+use std::{collections::HashMap, sync::Arc};
+
 use anyhow::Result;
 use futures::prelude::*;
 use regex::Regex;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 use wikibase::mediawiki::api::Api;
+
+use crate::{
+    generic_author_info::GenericAuthorInfo, wikidata_interaction::WikidataInteraction,
+    wikidata_papers::WikidataPapers, wikidata_string_cache::WikidataStringCache,
+};
 
 lazy_static! {
     static ref RE_WD: Regex =
@@ -31,7 +33,8 @@ impl AuthorNameString {
     }
 
     /// Splits a name into atomic parts, handling dots as separators.
-    /// E.g., "C.K. Clarke" → ["C", "K", "Clarke"], "Ck Clarke" → ["Ck", "Clarke"]
+    /// E.g., "C.K. Clarke" → ["C", "K", "Clarke"], "Ck Clarke" → ["Ck",
+    /// "Clarke"]
     fn split_name_parts(name: &str) -> Vec<String> {
         let mut parts = Vec::new();
         for word in name.split_whitespace() {
@@ -45,12 +48,11 @@ impl AuthorNameString {
         parts
     }
 
-    /// Returns true if the name contains any word-parts shorter than 3 characters
-    /// (i.e., initials or two-letter abbreviations that `simplify_name` would drop).
+    /// Returns true if the name contains any word-parts shorter than 3
+    /// characters (i.e., initials or two-letter abbreviations that
+    /// `simplify_name` would drop).
     pub fn has_short_name_parts(name: &str) -> bool {
-        Self::split_name_parts(name)
-            .iter()
-            .any(|p| p.len() < 3)
+        Self::split_name_parts(name).iter().any(|p| p.len() < 3)
     }
 
     /// Converts a name like "Ck Clarke" or "C K Clarke" or "C.K. Clarke"
@@ -77,10 +79,7 @@ impl AuthorNameString {
         if formatted.is_empty() {
             return None;
         }
-        let url = format!(
-            "https://wd-infernal.toolforge.org/initial_search/{}",
-            formatted
-        );
+        let url = format!("https://wd-infernal.toolforge.org/initial_search/{}", formatted);
         let response = reqwest::get(&url).await.ok()?;
         let results: Vec<String> = response.json().await.ok()?;
         Some(results)
@@ -94,10 +93,7 @@ impl AuthorNameString {
         paper_qs: &Vec<String>,
         name2author_qs: &HashMap<String, Vec<String>>,
     ) -> Result<()> {
-        let author_q = match self
-            .get_or_create_author(ans, cache, mw_api, name2author_qs)
-            .await
-        {
+        let author_q = match self.get_or_create_author(ans, cache, mw_api, name2author_qs).await {
             Some(q) => q,
             None => return Ok(()),
         };
@@ -115,10 +111,7 @@ impl AuthorNameString {
             .await;
         if !edited_qs.is_empty() {
             let api = mw_api.read().await;
-            papers
-                .entities_mut()
-                .reload_entities(&api, &edited_qs)
-                .await?;
+            papers.entities_mut().reload_entities(&api, &edited_qs).await?;
             drop(api);
         }
         Ok(())
@@ -147,18 +140,12 @@ impl AuthorNameString {
                 "Changing {ans} to {} [#Papers ANS (was: SourceMD)]",
                 "[[".to_string() + &author_q + "]]"
             )));
-            match papers
-                .apply_diff_for_item(original_item, item, mw_api.clone())
-                .await
-            {
+            match papers.apply_diff_for_item(original_item, item, mw_api.clone()).await {
                 Some(er) => {
                     if er.edited() {
                         self.log(
                             1,
-                            format!(
-                                "Created or updated https://www.wikidata.org/wiki/{}",
-                                er.q()
-                            ),
+                            format!("Created or updated https://www.wikidata.org/wiki/{}", er.q()),
                         );
                         edited_qs.push(er.q().to_string());
                     } else {
@@ -167,7 +154,7 @@ impl AuthorNameString {
                             format!("https://www.wikidata.org/wiki/{}, no changes ", er.q()),
                         );
                     }
-                }
+                },
                 None => self.log(1, "No paper item ID!"),
             }
             // papers.set_edit_summary(None);
@@ -189,7 +176,7 @@ impl AuthorNameString {
                 if initial_results.len() == 1 {
                     let candidate = &initial_results[0];
                     // Cross-check: the candidate must be a known coauthor
-                    for (_name, qs) in name2author_qs.iter() {
+                    for qs in name2author_qs.values() {
                         if qs.contains(candidate) {
                             self.log(
                                 1,
@@ -199,16 +186,14 @@ impl AuthorNameString {
                         }
                     }
                 }
-                // Multiple results or no coauthor match: fall through to existing logic
+                // Multiple results or no coauthor match: fall through to
+                // existing logic
             }
         }
 
         let simple_name = GenericAuthorInfo::simplify_name(ans);
         let res = cache
-            .search_wikibase(
-                &format!("{simple_name} haswbstatement:P31=Q5"),
-                mw_api.clone(),
-            )
+            .search_wikibase(&format!("{simple_name} haswbstatement:P31=Q5"), mw_api.clone())
             .await
             .ok()?;
         let author_q = if res.is_empty() {
@@ -217,10 +202,7 @@ impl AuthorNameString {
             if let Some(author_qs) = name2author_qs.get(ans) {
                 if author_qs.len() == 1 {
                     let author_q = &author_qs[0];
-                    self.log(
-                        1,
-                        format!("MATCHED AUTHOR {ans}: {simple_name} => {author_q}"),
-                    );
+                    self.log(1, format!("MATCHED AUTHOR {ans}: {simple_name} => {author_q}"));
                     Some(author_q.to_owned())
                 } else {
                     None
@@ -229,10 +211,7 @@ impl AuthorNameString {
                 None
             }
         } else {
-            self.log(
-                2,
-                format!("MULTIPLE POSSIBLE MATCHES FOR {ans}: {simple_name} => {res:?}"),
-            );
+            self.log(2, format!("MULTIPLE POSSIBLE MATCHES FOR {ans}: {simple_name} => {res:?}"));
             None
         };
         author_q
@@ -244,7 +223,7 @@ impl AuthorNameString {
         mw_api: &Arc<RwLock<Api>>,
         cache: &Arc<WikidataStringCache>,
     ) -> Result<()> {
-        self.log(1, format!("Processing {}", &root_author_q));
+        self.log(1, format!("Processing {}", root_author_q));
         let mut author = GenericAuthorInfo::new();
         author.set_wikidata_item(Some(root_author_q.to_owned()));
         let api = mw_api.read().await;
@@ -282,9 +261,7 @@ impl AuthorNameString {
             .iter()
             .filter_map(|j| {
                 let ans = j["ans"]["value"].as_str()?;
-                let q = api
-                    .extract_entity_from_uri(j["paper"]["value"].as_str()?)
-                    .ok()?;
+                let q = api.extract_entity_from_uri(j["paper"]["value"].as_str()?).ok()?;
                 Some((q.to_string(), ans.to_string()))
             })
             .collect();
@@ -342,9 +319,7 @@ impl AuthorNameString {
         self.log(1, format!("CREATING AUTHOR {ans}"));
         let mut author = GenericAuthorInfo::new();
         author.set_name(Some(ans.clone()));
-        let author = author
-            .get_or_create_author_item(mw_api.clone(), cache.clone(), true)
-            .await;
+        let author = author.get_or_create_author_item(mw_api.clone(), cache.clone(), true).await;
         self.log(1, format!("CREATED AUTHOR {ans} => {author:?}"));
         Some(author.wikidata_item()?.to_string())
     }
@@ -372,42 +347,24 @@ mod tests {
 
     #[test]
     fn format_name_for_initial_search_basic() {
-        assert_eq!(
-            AuthorNameString::format_name_for_initial_search("Ck Clarke"),
-            "C.K.Clarke"
-        );
-        assert_eq!(
-            AuthorNameString::format_name_for_initial_search("C K Clarke"),
-            "C.K.Clarke"
-        );
+        assert_eq!(AuthorNameString::format_name_for_initial_search("Ck Clarke"), "C.K.Clarke");
+        assert_eq!(AuthorNameString::format_name_for_initial_search("C K Clarke"), "C.K.Clarke");
     }
 
     #[test]
     fn format_name_for_initial_search_dotted() {
-        assert_eq!(
-            AuthorNameString::format_name_for_initial_search("C.K. Clarke"),
-            "C.K.Clarke"
-        );
-        assert_eq!(
-            AuthorNameString::format_name_for_initial_search("H.M. Manske"),
-            "H.M.Manske"
-        );
+        assert_eq!(AuthorNameString::format_name_for_initial_search("C.K. Clarke"), "C.K.Clarke");
+        assert_eq!(AuthorNameString::format_name_for_initial_search("H.M. Manske"), "H.M.Manske");
     }
 
     #[test]
     fn format_name_for_initial_search_single_initial() {
-        assert_eq!(
-            AuthorNameString::format_name_for_initial_search("J Smith"),
-            "J.Smith"
-        );
+        assert_eq!(AuthorNameString::format_name_for_initial_search("J Smith"), "J.Smith");
     }
 
     #[test]
     fn format_name_for_initial_search_full_name() {
         // Full names without initials: no dots added
-        assert_eq!(
-            AuthorNameString::format_name_for_initial_search("Jenny Clarke"),
-            "JennyClarke"
-        );
+        assert_eq!(AuthorNameString::format_name_for_initial_search("Jenny Clarke"), "JennyClarke");
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,33 +1,25 @@
 #[macro_use]
 extern crate lazy_static;
 
-use crate::sourcemd_command::SourceMDcommand;
-use crate::wikidata_string_cache::WikidataStringCache;
+use std::{io, io::prelude::*, sync::Arc, time::Duration};
+
 use futures::prelude::*;
-use papers::arxiv2wikidata::Arxiv2Wikidata;
-use papers::author_name_string::AuthorNameString;
-use papers::crossref2wikidata::Crossref2Wikidata;
-use papers::datacite2wikidata::DataCite2Wikidata;
-use papers::europepmc2wikidata::EuropePMC2Wikidata;
-use papers::identifiers::GenericWorkIdentifier;
-use papers::openalex2wikidata::OpenAlex2Wikidata;
-use papers::orcid2wikidata::Orcid2Wikidata;
-use papers::pmc2wikidata::PMC2Wikidata;
-use papers::pubmed2wikidata::Pubmed2Wikidata;
-use papers::semanticscholar2wikidata::Semanticscholar2Wikidata;
-use papers::sourcemd_bot::SourceMDbot;
-use papers::sourcemd_config::SourceMD;
-use papers::wikidata_papers::WikidataPapers;
-use papers::*;
+use papers::{
+    arxiv2wikidata::Arxiv2Wikidata, author_name_string::AuthorNameString,
+    crossref2wikidata::Crossref2Wikidata, datacite2wikidata::DataCite2Wikidata,
+    europepmc2wikidata::EuropePMC2Wikidata, identifiers::GenericWorkIdentifier,
+    openalex2wikidata::OpenAlex2Wikidata, orcid2wikidata::Orcid2Wikidata,
+    pmc2wikidata::PMC2Wikidata, pubmed2wikidata::Pubmed2Wikidata,
+    semanticscholar2wikidata::Semanticscholar2Wikidata, sourcemd_bot::SourceMDbot,
+    sourcemd_config::SourceMD, wikidata_papers::WikidataPapers, *,
+};
+use pico_args::Arguments;
 use rand::seq::SliceRandom;
 use regex::Regex;
-use pico_args::Arguments;
-use std::io;
-use std::io::prelude::*;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::RwLock;
 use wikibase::mediawiki::api::Api;
+
+use crate::{sourcemd_command::SourceMDcommand, wikidata_string_cache::WikidataStringCache};
 
 const INI_FILE: &str = "bot.ini";
 
@@ -44,16 +36,14 @@ async fn command_authors(ini_file: &str) {
         if line.is_empty() {
             continue;
         }
-        println!("Processing {}", &line);
+        println!("Processing {}", line);
         author_from_id(&line, cache.clone(), smd.clone()).await;
     }
 }
 
 async fn author_from_id(id: &str, cache: Arc<WikidataStringCache>, smd: Arc<RwLock<SourceMD>>) {
     let mut command = SourceMDcommand::new_dummy(id);
-    let bot = SourceMDbot::new(smd.clone(), cache.clone(), 0)
-        .await
-        .unwrap();
+    let bot = SourceMDbot::new(smd.clone(), cache.clone(), 0).await.unwrap();
     bot.process_author_metadata(&mut command).await.unwrap();
 }
 
@@ -67,7 +57,7 @@ async fn command_ans(ini_file: &str) {
     let mut futures: Vec<_> = io::stdin()
         .lock()
         .lines()
-        /* trunk-ignore(clippy/lines_filter_map_ok) */
+        // trunk-ignore(clippy/lines_filter_map_ok)
         .map_while(Result::ok)
         .map(|line| line.trim().to_string())
         .filter(|line| !line.is_empty())
@@ -80,9 +70,7 @@ async fn command_ans(ini_file: &str) {
 }
 
 async fn command_papers(ini_file: &str) {
-    let mw_api = Arc::new(RwLock::new(
-        SourceMD::create_mw_api(ini_file).await.unwrap(),
-    ));
+    let mw_api = Arc::new(RwLock::new(SourceMD::create_mw_api(ini_file).await.unwrap()));
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let line = match line {
@@ -92,7 +80,7 @@ async fn command_papers(ini_file: &str) {
         if line.is_empty() {
             continue;
         }
-        //println!("Processing {}", &line);
+        // println!("Processing {}", &line);
         paper_from_id(&line, mw_api.clone()).await;
     }
 }
@@ -106,7 +94,7 @@ async fn paper_from_id(id: &str, mw_api: Arc<RwLock<Api>>) {
     let cache = Arc::new(WikidataStringCache::new(mw_api.clone()));
 
     let mut wdp = WikidataPapers::new(cache.clone());
-    //wdp.testing = true;
+    // wdp.testing = true;
     wdp.add_adapter(Box::new(PMC2Wikidata::new()));
     wdp.add_adapter(Box::new(Pubmed2Wikidata::new()));
     wdp.add_adapter(Box::new(Crossref2Wikidata::new()));
@@ -128,10 +116,10 @@ async fn paper_from_id(id: &str, mw_api: Arc<RwLock<Api>>) {
     ids.retain(|id| !id.id().is_empty());
 
     if ids.is_empty() {
-        println!("Can't find a valid ID in '{}'", &id);
+        println!("Can't find a valid ID in '{}'", id);
         return;
     }
-    //println!("IDs: {:?}", &ids);
+    // println!("IDs: {:?}", &ids);
     ids = wdp.update_from_paper_ids(&ids).await;
 
     match wdp.create_or_update_item_from_ids(mw_api, &ids).await {
@@ -139,13 +127,10 @@ async fn paper_from_id(id: &str, mw_api: Arc<RwLock<Api>>) {
             if er.edited() {
                 println!("Created or updated https://www.wikidata.org/wiki/{}", er.q())
             } else {
-                println!(
-                    "Exists as https://www.wikidata.org/wiki/{}, no changes ",
-                    er.q()
-                )
+                println!("Exists as https://www.wikidata.org/wiki/{}, no changes ", er.q())
             }
-        }
-        None => println!("No item ID for '{}'!", &id),
+        },
+        None => println!("No item ID for '{}'!", id),
     }
 }
 
@@ -157,7 +142,7 @@ async fn save_item_changes(wdp: &mut WikidataPapers, mw_api: Arc<RwLock<Api>>, q
             } else {
                 println!("https://www.wikidata.org/wiki/{}, no changes ", er.q())
             }
-        }
+        },
         None => println!("No item ID!"),
     }
 }
@@ -170,7 +155,7 @@ fn usage(prog: &str) {
 
 /// Returns true if a new batch was started, false otherwise
 async fn run_bot(config: Arc<RwLock<SourceMD>>, cache: Arc<WikidataStringCache>) -> bool {
-    //println!("BOT!");
+    // println!("BOT!");
     let batch_id = match config.read().await.get_next_batch().await {
         Some(n) => n,
         None => return false, // Nothing to do
@@ -180,13 +165,10 @@ async fn run_bot(config: Arc<RwLock<SourceMD>>, cache: Arc<WikidataStringCache>)
     let bot = match SourceMDbot::new(config.clone(), cache.clone(), batch_id).await {
         Ok(bot) => bot,
         Err(error) => {
-            println!(
-                "Error when starting bot for batch #{}: '{}'",
-                &batch_id, &error
-            );
+            println!("Error when starting bot for batch #{}: '{}'", batch_id, error);
             config.read().await.set_batch_failed(batch_id).await;
             return false;
-        }
+        },
     };
 
     println!("Batch #{} spawned", batch_id);
@@ -200,12 +182,10 @@ async fn command_bot(ini_file: &str) {
     let mut smd = SourceMD::new(ini_file).await.unwrap();
     smd.init();
     let smd = Arc::new(RwLock::new(smd));
-    let mw_api = Arc::new(RwLock::new(
-        SourceMD::create_mw_api(ini_file).await.unwrap(),
-    ));
+    let mw_api = Arc::new(RwLock::new(SourceMD::create_mw_api(ini_file).await.unwrap()));
     let cache = Arc::new(WikidataStringCache::new(mw_api));
     loop {
-        //println!("BOT!");
+        // println!("BOT!");
         if run_bot(smd.clone(), cache.clone()).await {
             tokio::time::sleep(Duration::from_millis(1000)).await;
         } else {
@@ -214,10 +194,8 @@ async fn command_bot(ini_file: &str) {
     }
 }
 
-/*
-For local testing:
-ssh magnus@tools-login.wmflabs.org -L 3307:tools-db:3306 -N &
-*/
+// For local testing:
+// ssh magnus@tools-login.wmflabs.org -L 3307:tools-db:3306 -N &
 
 #[tokio::main]
 async fn main() {

--- a/src/crossref2wikidata.rs
+++ b/src/crossref2wikidata.rs
@@ -1,12 +1,14 @@
-use crate::scientific_publication_adapter::{crossref_work_type_to_q, ScientificPublicationAdapter};
-use crate::*;
-use async_trait::async_trait;
-use chrono::prelude::*;
-use crossref::response::work::PartialDate;
-use crossref::Crossref;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+use chrono::prelude::*;
+use crossref::{response::work::PartialDate, Crossref};
+
 use self::identifiers::{GenericWorkIdentifier, GenericWorkType, IdProp};
+use crate::{
+    scientific_publication_adapter::{crossref_work_type_to_q, ScientificPublicationAdapter},
+    *,
+};
 
 pub struct Crossref2Wikidata {
     author_cache: HashMap<String, String>,
@@ -67,8 +69,16 @@ fn parse_crossref_date(issued: &PartialDate) -> Option<(u32, Option<u8>, Option<
         return None;
     }
     let year = dp[0].as_u64()? as u32;
-    let month = if dp.len() >= 2 { dp[1].as_u64().map(|x| x as u8) } else { None };
-    let day = if dp.len() >= 3 { dp[2].as_u64().map(|x| x as u8) } else { None };
+    let month = if dp.len() >= 2 {
+        dp[1].as_u64().map(|x| x as u8)
+    } else {
+        None
+    };
+    let day = if dp.len() >= 3 {
+        dp[2].as_u64().map(|x| x as u8)
+    } else {
+        None
+    };
     Some((year, month, day))
 }
 
@@ -150,11 +160,7 @@ impl ScientificPublicationAdapter for Crossref2Wikidata {
 
     fn get_work_titles(&self, publication_id: &str) -> Vec<LocaleString> {
         match self.get_cached_publication_from_id(publication_id) {
-            Some(work) => work
-                .title
-                .iter()
-                .map(|t| LocaleString::new("en", t))
-                .collect(),
+            Some(work) => work.title.iter().map(|t| LocaleString::new("en", t)).collect(),
             None => vec![],
         }
     }
@@ -173,18 +179,14 @@ impl ScientificPublicationAdapter for Crossref2Wikidata {
         // Date
         if !item.has_claims_with_property("P577") {
             if let Some((year, month, day)) = self.get_publication_date(publication_id) {
-                let statement =
-                    self.get_wb_time_from_partial("P577".to_string(), year, month, day);
+                let statement = self.get_wb_time_from_partial("P577".to_string(), year, month, day);
                 item.add_claim(statement);
             }
         }
 
         // Issue/volume/page
-        let string_options = vec![
-            ("P433", &work.issue),
-            ("P478", &work.volume),
-            ("P304", &work.page),
-        ];
+        let string_options =
+            vec![("P433", &work.issue), ("P478", &work.volume), ("P304", &work.page)];
         for option in string_options {
             if !item.has_claims_with_property(option.0) {
                 if let Some(v) = option.1 {
@@ -201,7 +203,7 @@ impl ScientificPublicationAdapter for Crossref2Wikidata {
 
         if let Some(subjects) = &work.subject {
             for _subject in subjects {
-                //println!("Subject:{}", &subject);
+                // println!("Subject:{}", &subject);
                 // TODO
             }
         }
@@ -225,42 +227,24 @@ mod tests {
     #[test]
     fn test_crossref_type_to_q_book() {
         assert_eq!(crossref_work_type_to_q("book"), Some("Q571"));
-        assert_eq!(
-            crossref_work_type_to_q("edited-book"),
-            Some("Q571")
-        );
-        assert_eq!(
-            crossref_work_type_to_q("reference-book"),
-            Some("Q571")
-        );
+        assert_eq!(crossref_work_type_to_q("edited-book"), Some("Q571"));
+        assert_eq!(crossref_work_type_to_q("reference-book"), Some("Q571"));
     }
 
     #[test]
     fn test_crossref_type_to_q_monograph() {
-        assert_eq!(
-            crossref_work_type_to_q("monograph"),
-            Some("Q193495")
-        );
+        assert_eq!(crossref_work_type_to_q("monograph"), Some("Q193495"));
     }
 
     #[test]
     fn test_crossref_type_to_q_chapter() {
-        assert_eq!(
-            crossref_work_type_to_q("book-chapter"),
-            Some("Q1980247")
-        );
-        assert_eq!(
-            crossref_work_type_to_q("book-section"),
-            Some("Q1980247")
-        );
+        assert_eq!(crossref_work_type_to_q("book-chapter"), Some("Q1980247"));
+        assert_eq!(crossref_work_type_to_q("book-section"), Some("Q1980247"));
     }
 
     #[test]
     fn test_crossref_type_to_q_unknown_returns_none() {
-        assert_eq!(
-            crossref_work_type_to_q("unknown-type"),
-            None
-        );
+        assert_eq!(crossref_work_type_to_q("unknown-type"), None);
     }
 
     // === should_add_string ===
@@ -277,7 +261,8 @@ mod tests {
         let c = Crossref2Wikidata::new();
         assert!(c.should_add_string("1"));
         assert!(c.should_add_string("some-value"));
-        assert!(c.should_add_string("N/A")); // case-sensitive: uppercase is accepted
+        assert!(c.should_add_string("N/A")); // case-sensitive: uppercase is
+                                             // accepted
     }
 
     #[test]
@@ -288,13 +273,7 @@ mod tests {
 
     #[test]
     fn test_crossref_type_to_q_proceedings() {
-        assert_eq!(
-            crossref_work_type_to_q("proceedings-article"),
-            Some("Q23927052")
-        );
-        assert_eq!(
-            crossref_work_type_to_q("proceedings"),
-            Some("Q1143604")
-        );
+        assert_eq!(crossref_work_type_to_q("proceedings-article"), Some("Q23927052"));
+        assert_eq!(crossref_work_type_to_q("proceedings"), Some("Q1143604"));
     }
 }

--- a/src/datacite2wikidata.rs
+++ b/src/datacite2wikidata.rs
@@ -1,10 +1,12 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
-use async_trait::async_trait;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+
 use self::identifiers::{GenericWorkIdentifier, GenericWorkType, IdProp};
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter, *,
+};
 
 pub struct DataCite2Wikidata {
     author_cache: HashMap<String, String>,
@@ -35,9 +37,7 @@ impl DataCite2Wikidata {
     /// Returns the `data.attributes` object from the cached JSON:API response.
     fn get_attributes(&self, publication_id: &str) -> Option<&serde_json::Value> {
         let work = self.get_cached_publication_from_id(publication_id)?;
-        work["data"]["attributes"]
-            .as_object()
-            .map(|_| &work["data"]["attributes"])
+        work["data"]["attributes"].as_object().map(|_| &work["data"]["attributes"])
     }
 
     async fn fetch_doi_data(doi: &str) -> Option<(String, serde_json::Value)> {
@@ -134,7 +134,7 @@ impl ScientificPublicationAdapter for DataCite2Wikidata {
                     }
                 }
                 vec![]
-            }
+            },
             _ => vec![],
         }
     }
@@ -181,10 +181,7 @@ impl ScientificPublicationAdapter for DataCite2Wikidata {
             .enumerate()
             .filter_map(|(num, creator)| {
                 // Try familyName + givenName, fall back to name
-                let name = match (
-                    creator["givenName"].as_str(),
-                    creator["familyName"].as_str(),
-                ) {
+                let name = match (creator["givenName"].as_str(), creator["familyName"].as_str()) {
                     (Some(given), Some(family)) => format!("{} {}", given, family),
                     _ => creator["name"].as_str()?.to_string(),
                 };
@@ -201,7 +198,9 @@ impl ScientificPublicationAdapter for DataCite2Wikidata {
                                 let orcid =
                                     orcid.strip_prefix("https://orcid.org/").unwrap_or(orcid);
                                 if !orcid.is_empty() {
-                                    entry.prop2id_mut().insert("P496".to_string(), orcid.to_string());
+                                    entry
+                                        .prop2id_mut()
+                                        .insert("P496".to_string(), orcid.to_string());
                                 }
                             }
                         }
@@ -294,9 +293,7 @@ mod tests {
         let mut adapter = DataCite2Wikidata::new();
         let mut work = make_datacite_work();
         work["data"]["attributes"]["titles"] = json!([]);
-        adapter
-            .work_cache
-            .insert("10.5281/ZENODO.1234567".to_string(), work);
+        adapter.work_cache.insert("10.5281/ZENODO.1234567".to_string(), work);
         assert!(adapter.get_work_titles("10.5281/ZENODO.1234567").is_empty());
     }
 
@@ -306,10 +303,7 @@ mod tests {
         adapter
             .work_cache
             .insert("10.5281/ZENODO.1234567".to_string(), make_datacite_work());
-        assert_eq!(
-            adapter.get_work_type("10.5281/ZENODO.1234567"),
-            Some("Q1172284".to_string())
-        );
+        assert_eq!(adapter.get_work_type("10.5281/ZENODO.1234567"), Some("Q1172284".to_string()));
     }
 
     #[test]
@@ -317,26 +311,15 @@ mod tests {
         let mut adapter = DataCite2Wikidata::new();
         let mut work = make_datacite_work();
         work["data"]["attributes"]["types"]["resourceTypeGeneral"] = json!("Software");
-        adapter
-            .work_cache
-            .insert("10.5281/ZENODO.1234567".to_string(), work);
-        assert_eq!(
-            adapter.get_work_type("10.5281/ZENODO.1234567"),
-            Some("Q7397".to_string())
-        );
+        adapter.work_cache.insert("10.5281/ZENODO.1234567".to_string(), work);
+        assert_eq!(adapter.get_work_type("10.5281/ZENODO.1234567"), Some("Q7397".to_string()));
     }
 
     #[test]
     fn test_datacite_type_to_q() {
         assert_eq!(DataCite2Wikidata::datacite_type_to_q("Book"), Some("Q571"));
-        assert_eq!(
-            DataCite2Wikidata::datacite_type_to_q("Dataset"),
-            Some("Q1172284")
-        );
-        assert_eq!(
-            DataCite2Wikidata::datacite_type_to_q("JournalArticle"),
-            Some("Q13442814")
-        );
+        assert_eq!(DataCite2Wikidata::datacite_type_to_q("Dataset"), Some("Q1172284"));
+        assert_eq!(DataCite2Wikidata::datacite_type_to_q("JournalArticle"), Some("Q13442814"));
         assert_eq!(DataCite2Wikidata::datacite_type_to_q("Unknown"), None);
     }
 
@@ -357,9 +340,7 @@ mod tests {
         let mut adapter = DataCite2Wikidata::new();
         let mut work = make_datacite_work();
         work["data"]["attributes"]["dates"] = json!([]);
-        adapter
-            .work_cache
-            .insert("10.5281/ZENODO.1234567".to_string(), work);
+        adapter.work_cache.insert("10.5281/ZENODO.1234567".to_string(), work);
         assert_eq!(
             adapter.get_publication_date("10.5281/ZENODO.1234567"),
             Some((2023, None, None))
@@ -376,10 +357,7 @@ mod tests {
         assert_eq!(authors.len(), 2);
         assert_eq!(authors[0].name(), Some("Alice Smith"));
         assert_eq!(authors[0].list_number(), Some("1"));
-        assert_eq!(
-            authors[0].prop2id().get("P496"),
-            Some(&"0000-0001-2345-6789".to_string())
-        );
+        assert_eq!(authors[0].prop2id().get("P496"), Some(&"0000-0001-2345-6789".to_string()));
         assert_eq!(authors[1].name(), Some("Bob Jones"));
         assert_eq!(authors[1].list_number(), Some("2"));
         assert!(!authors[1].prop2id().contains_key("P496"));
@@ -395,9 +373,7 @@ mod tests {
                 "nameIdentifiers": []
             }
         ]);
-        adapter
-            .work_cache
-            .insert("10.5281/ZENODO.1234567".to_string(), work);
+        adapter.work_cache.insert("10.5281/ZENODO.1234567".to_string(), work);
         let authors = adapter.get_author_list("10.5281/ZENODO.1234567").await;
         assert_eq!(authors.len(), 1);
         assert_eq!(authors[0].name(), Some("CERN Data Team"));
@@ -408,12 +384,7 @@ mod tests {
         let mut adapter = DataCite2Wikidata::new();
         let mut work = make_datacite_work();
         work["data"]["attributes"]["creators"] = json!([]);
-        adapter
-            .work_cache
-            .insert("10.5281/ZENODO.1234567".to_string(), work);
-        assert!(adapter
-            .get_author_list("10.5281/ZENODO.1234567")
-            .await
-            .is_empty());
+        adapter.work_cache.insert("10.5281/ZENODO.1234567".to_string(), work);
+        assert!(adapter.get_author_list("10.5281/ZENODO.1234567").await.is_empty());
     }
 }

--- a/src/europepmc2wikidata.rs
+++ b/src/europepmc2wikidata.rs
@@ -1,10 +1,12 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
-use async_trait::async_trait;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+
 use self::identifiers::{GenericWorkIdentifier, GenericWorkType, IdProp};
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter, *,
+};
 
 pub struct EuropePMC2Wikidata {
     author_cache: HashMap<String, String>,
@@ -156,12 +158,8 @@ impl ScientificPublicationAdapter for EuropePMC2Wikidata {
 
         // Fall back to journalInfo
         let year = work["journalInfo"]["yearOfPublication"].as_u64()? as u32;
-        let month = work["journalInfo"]["monthOfPublication"]
-            .as_u64()
-            .map(|x| x as u8);
-        let day = work["journalInfo"]["dayOfPublication"]
-            .as_u64()
-            .map(|x| x as u8);
+        let month = work["journalInfo"]["monthOfPublication"].as_u64().map(|x| x as u8);
+        let day = work["journalInfo"]["dayOfPublication"].as_u64().map(|x| x as u8);
         Some((year, month, day))
     }
 
@@ -247,9 +245,7 @@ mod tests {
     #[test]
     fn test_get_work_titles() {
         let mut adapter = EuropePMC2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_epmc_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_epmc_work());
         let titles = adapter.get_work_titles("10.1234/TEST");
         assert_eq!(titles.len(), 1);
         assert_eq!(titles[0].value(), "Test Article Title");
@@ -273,13 +269,8 @@ mod tests {
     #[test]
     fn test_get_publication_date_from_first_publication_date() {
         let mut adapter = EuropePMC2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_epmc_work());
-        assert_eq!(
-            adapter.get_publication_date("10.1234/TEST"),
-            Some((2023, Some(6), Some(15)))
-        );
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_epmc_work());
+        assert_eq!(adapter.get_publication_date("10.1234/TEST"), Some((2023, Some(6), Some(15))));
     }
 
     #[test]
@@ -288,18 +279,13 @@ mod tests {
         let mut work = make_epmc_work();
         work["firstPublicationDate"] = json!(null);
         adapter.work_cache.insert("10.1234/TEST".to_string(), work);
-        assert_eq!(
-            adapter.get_publication_date("10.1234/TEST"),
-            Some((2023, Some(6), None))
-        );
+        assert_eq!(adapter.get_publication_date("10.1234/TEST"), Some((2023, Some(6), None)));
     }
 
     #[test]
     fn test_get_volume_and_issue() {
         let mut adapter = EuropePMC2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_epmc_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_epmc_work());
         assert_eq!(adapter.get_volume("10.1234/TEST"), Some("42".to_string()));
         assert_eq!(adapter.get_issue("10.1234/TEST"), Some("3".to_string()));
     }
@@ -307,21 +293,14 @@ mod tests {
     #[test]
     fn test_get_work_issn() {
         let mut adapter = EuropePMC2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_epmc_work());
-        assert_eq!(
-            adapter.get_work_issn("10.1234/TEST"),
-            Some("1234-5678".to_string())
-        );
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_epmc_work());
+        assert_eq!(adapter.get_work_issn("10.1234/TEST"), Some("1234-5678".to_string()));
     }
 
     #[tokio::test]
     async fn test_get_author_list() {
         let mut adapter = EuropePMC2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_epmc_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_epmc_work());
         let authors = adapter.get_author_list("10.1234/TEST").await;
         assert_eq!(authors.len(), 2);
         assert_eq!(authors[0].name(), Some("Alice Smith"));
@@ -348,23 +327,15 @@ mod tests {
     #[test]
     fn test_add_identifiers_from_cached_publication() {
         let mut adapter = EuropePMC2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_epmc_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_epmc_work());
         let mut ret = vec![];
         adapter.add_identifiers_from_cached_publication("10.1234/TEST", &mut ret);
-        assert!(ret.iter().any(
-            |id| *id.work_type() == GenericWorkType::Property(IdProp::DOI)
-                && id.id() == "10.1234/TEST"
-        ));
-        assert!(ret.iter().any(
-            |id| *id.work_type() == GenericWorkType::Property(IdProp::PMID)
-                && id.id() == "12345678"
-        ));
-        assert!(ret.iter().any(
-            |id| *id.work_type() == GenericWorkType::Property(IdProp::PMCID)
-                && id.id() == "PMC9876543"
-        ));
+        assert!(ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::DOI)
+            && id.id() == "10.1234/TEST"));
+        assert!(ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::PMID)
+            && id.id() == "12345678"));
+        assert!(ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::PMCID)
+            && id.id() == "PMC9876543"));
     }
 
     #[test]
@@ -376,8 +347,6 @@ mod tests {
         let mut ret = vec![];
         adapter.add_identifiers_from_cached_publication("10.1234/TEST", &mut ret);
         assert_eq!(ret.len(), 2); // DOI + PMID, no PMCID
-        assert!(!ret
-            .iter()
-            .any(|id| *id.work_type() == GenericWorkType::Property(IdProp::PMCID)));
+        assert!(!ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::PMCID)));
     }
 }

--- a/src/generic_author_info.rs
+++ b/src/generic_author_info.rs
@@ -1,13 +1,14 @@
-use crate::wikidata_interaction::WikidataInteraction;
-use crate::wikidata_string_cache::WikidataStringCache;
-use crate::*;
+use std::{collections::HashMap, sync::Arc};
+
 use anyhow::{anyhow, Result};
 use deunicode::deunicode;
 use regex::Regex;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 use wikibase::mediawiki::api::Api;
+
+use crate::{
+    wikidata_interaction::WikidataInteraction, wikidata_string_cache::WikidataStringCache, *,
+};
 
 const SCORE_LIST_NUMBER: u16 = 5;
 const SCORE_LIST_NUMBER_AND_NAME: u16 = 30;
@@ -63,7 +64,7 @@ impl GenericAuthorInfo {
                     match snak.property() {
                         "P1545" => ret.list_number = Some(s.to_string()),
                         "P1932" => ret.name = Some(s.to_string()),
-                        _ => {}
+                        _ => {},
                     }
                 }
             }
@@ -130,9 +131,10 @@ impl GenericAuthorInfo {
         }
     }
 
-    /// Returns true if there's a meaningful partial match with any author in the list.
-    /// Used to detect ambiguous matches that didn't meet the threshold for a definitive match.
-    /// Requires more than just a list number coincidence (score > SCORE_LIST_NUMBER).
+    /// Returns true if there's a meaningful partial match with any author in
+    /// the list. Used to detect ambiguous matches that didn't meet the
+    /// threshold for a definitive match. Requires more than just a list
+    /// number coincidence (score > SCORE_LIST_NUMBER).
     pub fn has_partial_match(&self, authors: &[GenericAuthorInfo]) -> bool {
         authors.iter().any(|a| self.compare(a) > SCORE_LIST_NUMBER)
     }
@@ -167,13 +169,13 @@ impl GenericAuthorInfo {
                     qualifiers.push(Snak::new_string("P1932", &name));
                 }
                 Statement::new_normal(Snak::new_item("P50", q), qualifiers, vec![])
-            }
+            },
             None => {
                 if name.is_empty() && qualifiers.is_empty() {
                     return None; // No addition
                 }
                 Statement::new_normal(Snak::new_string("P2093", &name), qualifiers, vec![])
-            }
+            },
         };
         Some(statement)
     }
@@ -237,13 +239,12 @@ impl GenericAuthorInfo {
                     if s != name && Self::add_aliases() {
                         item.add_alias(LocaleString::new("en", name));
                     }
-                }
+                },
                 None => item.set_label(LocaleString::new("en", name)),
             }
         }
 
-        item.descriptions_mut()
-            .push(LocaleString::new("en", "researcher"));
+        item.descriptions_mut().push(LocaleString::new("en", "researcher"));
 
         // Remaining names as aliases
         for n in &aliases {
@@ -252,22 +253,18 @@ impl GenericAuthorInfo {
                     if s != n && Self::add_aliases() {
                         item.add_alias(LocaleString::new("en", n));
                     }
-                }
+                },
                 None => {
                     if Self::add_aliases() {
                         item.add_alias(LocaleString::new("en", n));
                     }
-                }
+                },
             }
         }
 
         // Human
         if !item.has_target_entity("P31", "Q5") {
-            item.add_claim(Statement::new_normal(
-                Snak::new_item("P31", "Q5"),
-                vec![],
-                vec![],
-            ));
+            item.add_claim(Statement::new_normal(Snak::new_item("P31", "Q5"), vec![], vec![]));
         }
 
         // Researcher
@@ -337,7 +334,8 @@ impl GenericAuthorInfo {
         if self.name.is_none() {
             self.name = author2.name.clone();
         } else if let Some(name) = &author2.name {
-            self.alternative_names.push(name.to_owned()); // Sort/dedup at the end
+            self.alternative_names.push(name.to_owned()); // Sort/dedup at the
+                                                          // end
         }
         if self.wikidata_item.is_none() {
             self.wikidata_item = author2.wikidata_item.clone();
@@ -368,14 +366,13 @@ impl GenericAuthorInfo {
                             k, x, v, self.name, x
                         );
                     }
-                }
+                },
                 None => {
                     self.prop2id.insert(k.to_string(), v.to_string());
-                }
+                },
             }
         }
-        self.alternative_names
-            .extend(author2.alternative_names.iter().cloned());
+        self.alternative_names.extend(author2.alternative_names.iter().cloned());
         self.alternative_names.sort();
         self.alternative_names.dedup();
         Ok(())
@@ -400,15 +397,16 @@ impl GenericAuthorInfo {
         ret.trim().to_string()
     }
 
-    /// Collects all long (3+ char) words from a pre-processed name string, sorted.
+    /// Collects all long (3+ char) words from a pre-processed name string,
+    /// sorted.
     fn sorted_name_parts(re: &Regex, s: &str) -> Vec<String> {
         let mut parts: Vec<String> = re.captures_iter(s).map(|c| c[1].to_string()).collect();
         parts.sort();
         parts
     }
 
-    /// Returns true if two pre-processed (asciified, dots replaced) name strings
-    /// have conflicting initials after removing shared long words.
+    /// Returns true if two pre-processed (asciified, dots replaced) name
+    /// strings have conflicting initials after removing shared long words.
     /// E.g., "ck clarke" vs "jenny clarke" → true (c,k vs j conflict)
     /// "j smith" vs "john smith" → false (j matches j)
     /// "heinrich manske" vs "manske heinrich" → false (no remaining parts)
@@ -419,21 +417,14 @@ impl GenericAuthorInfo {
             static ref RE_ALL_C: Regex = Regex::new(r"\b(\w+)\b")
                 .expect("names_have_conflicting_initials: could not compile RE_ALL_C");
         }
-        let all1: Vec<String> = RE_ALL_C
-            .captures_iter(name1_mod)
-            .map(|c| c[1].to_string())
-            .collect();
-        let all2: Vec<String> = RE_ALL_C
-            .captures_iter(name2_mod)
-            .map(|c| c[1].to_string())
-            .collect();
+        let all1: Vec<String> =
+            RE_ALL_C.captures_iter(name1_mod).map(|c| c[1].to_string()).collect();
+        let all2: Vec<String> =
+            RE_ALL_C.captures_iter(name2_mod).map(|c| c[1].to_string()).collect();
         let parts1 = Self::sorted_name_parts(&RE_LONG_C, name1_mod);
         let parts2 = Self::sorted_name_parts(&RE_LONG_C, name2_mod);
-        let matched_words: Vec<String> = parts1
-            .iter()
-            .filter(|p| parts2.contains(p))
-            .cloned()
-            .collect();
+        let matched_words: Vec<String> =
+            parts1.iter().filter(|p| parts2.contains(p)).cloned().collect();
         let remaining1 = Self::remove_matched_words(&all1, &matched_words);
         let remaining2 = Self::remove_matched_words(&all2, &matched_words);
         if !remaining1.is_empty() && !remaining2.is_empty() {
@@ -444,8 +435,8 @@ impl GenericAuthorInfo {
         false
     }
 
-    /// Compares long (3+ characters) name parts, with initials compatibility check.
-    /// Returns 0 if the non-matching parts have conflicting initials
+    /// Compares long (3+ characters) name parts, with initials compatibility
+    /// check. Returns 0 if the non-matching parts have conflicting initials
     /// (e.g. "Bruce Allen" vs "G. Allen" — shared surname but B ≠ G).
     fn author_names_match(&self, name1: &str, name2: &str) -> u16 {
         lazy_static! {
@@ -483,8 +474,9 @@ impl GenericAuthorInfo {
     }
 
     /// Extracts initials from name parts.
-    /// Short parts (< 3 chars) contribute each character as a potential initial.
-    /// Long parts (>= 3 chars) contribute only their first character.
+    /// Short parts (< 3 chars) contribute each character as a potential
+    /// initial. Long parts (>= 3 chars) contribute only their first
+    /// character.
     fn extract_initials_from_parts(parts: &[String]) -> Vec<char> {
         let mut initials = Vec::new();
         for part in parts {
@@ -532,7 +524,8 @@ impl GenericAuthorInfo {
                 let l1 = self.get_longest_name_part();
                 let l2 = author2.get_longest_name_part();
                 if l1.is_some() && l2.is_some() && l1 == l2 {
-                    // Same longest name part — but only award higher score if initials are compatible
+                    // Same longest name part — but only award higher score if initials are
+                    // compatible
                     if let (Some(name1), Some(name2)) = (&self.name, &author2.name) {
                         let n1_mod = self.asciify_string(name1).replace('.', " ");
                         let n2_mod = self.asciify_string(name2).replace('.', " ");
@@ -604,7 +597,7 @@ impl GenericAuthorInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    //use wikibase::mediawiki::api::Api;
+    // use wikibase::mediawiki::api::Api;
 
     #[test]
     fn asciify_string() {
@@ -617,14 +610,8 @@ mod tests {
         let ga = GenericAuthorInfo::new();
         assert_eq!(ga.author_names_match("Manske M", "Manske HM"), 1);
         assert_eq!(ga.author_names_match("Manske M", "HM Manske"), 1);
-        assert_eq!(
-            ga.author_names_match("Heinrich M Manske", "manske heinrich"),
-            2
-        );
-        assert_eq!(
-            ga.author_names_match("Notmyname M Manske", "Heinrich M Manske"),
-            1
-        );
+        assert_eq!(ga.author_names_match("Heinrich M Manske", "manske heinrich"), 2);
+        assert_eq!(ga.author_names_match("Notmyname M Manske", "Heinrich M Manske"), 1);
     }
 
     #[test]
@@ -678,10 +665,7 @@ mod tests {
         assert_eq!(ga1.compare(&ga2), SCORE_LIST_NUMBER);
         ga1.name = Some("Foobar Baz".to_string());
         ga2.name = Some("Foobar B.".to_string());
-        assert_eq!(
-            ga1.compare(&ga2),
-            SCORE_LIST_NUMBER_AND_NAME + SCORE_NAME_MATCH
-        );
+        assert_eq!(ga1.compare(&ga2), SCORE_LIST_NUMBER_AND_NAME + SCORE_NAME_MATCH);
         ga1.name = None;
         ga2.name = None;
         ga1.list_number = Some("456".to_string());
@@ -724,8 +708,7 @@ mod tests {
         let mut ga = GenericAuthorInfo::new();
         ga.name = Some("Magnus Manske".to_string());
         ga.alternative_names.push("HM Manske".to_string());
-        ga.prop2id
-            .insert("P496".to_string(), "1234-5678-1234-5678".to_string());
+        ga.prop2id.insert("P496".to_string(), "1234-5678-1234-5678".to_string());
         let mut item = Entity::new_empty_item();
         ga.amend_author_item(&mut item);
         assert_eq!(item.label_in_locale("en"), Some("Magnus Manske"));
@@ -734,10 +717,7 @@ mod tests {
             assert_eq!(*item.aliases(), vec![LocaleString::new("en", "HM Manske")]);
         }
         assert_eq!(*item.claims()[0].main_snak(), Snak::new_item("P31", "Q5"));
-        assert_eq!(
-            *item.claims()[1].main_snak(),
-            Snak::new_item("P106", "Q1650915")
-        );
+        assert_eq!(*item.claims()[1].main_snak(), Snak::new_item("P106", "Q1650915"));
         assert_eq!(
             *item.claims()[2].main_snak(),
             Snak::new_external_id("P496", "1234-5678-1234-5678")
@@ -810,22 +790,19 @@ mod tests {
         let mut ga2 = GenericAuthorInfo::new();
         ga2.name = Some("J Smith".to_string());
         ga2.list_number = Some("1".to_string());
-        ga2.prop2id
-            .insert("P496".to_string(), "0000-1234-5678-9012".to_string());
+        ga2.prop2id.insert("P496".to_string(), "0000-1234-5678-9012".to_string());
 
         assert!(ga1.merge_from(&ga2).is_ok());
         assert_eq!(ga1.name, Some("John Smith".to_string())); // primary name kept
         assert!(ga1.alternative_names.contains(&"J Smith".to_string())); // secondary added as alias
-        assert_eq!(
-            ga1.prop2id.get("P496"),
-            Some(&"0000-1234-5678-9012".to_string())
-        ); // prop absorbed
+        assert_eq!(ga1.prop2id.get("P496"), Some(&"0000-1234-5678-9012".to_string())); // prop absorbed
         assert_eq!(ga1.list_number, Some("1".to_string()));
     }
 
     #[test]
     fn merge_from_conflicting_list_numbers_succeeds() {
-        // Previously this would return Err; now it should succeed and keep existing number.
+        // Previously this would return Err; now it should succeed and keep existing
+        // number.
         let mut ga1 = GenericAuthorInfo::new();
         ga1.name = Some("John Smith".to_string());
         ga1.list_number = Some("1".to_string());
@@ -840,23 +817,18 @@ mod tests {
 
     #[test]
     fn merge_from_conflicting_prop2id_succeeds_keeps_existing() {
-        // Previously this would return Err; now it should succeed and keep existing value.
+        // Previously this would return Err; now it should succeed and keep existing
+        // value.
         let mut ga1 = GenericAuthorInfo::new();
-        ga1.prop2id
-            .insert("P496".to_string(), "0000-1111-2222-3333".to_string());
+        ga1.prop2id.insert("P496".to_string(), "0000-1111-2222-3333".to_string());
 
         let mut ga2 = GenericAuthorInfo::new();
-        ga2.prop2id
-            .insert("P496".to_string(), "9999-8888-7777-6666".to_string()); // Conflict
-        ga2.prop2id
-            .insert("P1053".to_string(), "A-1234-5678".to_string()); // New, no conflict
+        ga2.prop2id.insert("P496".to_string(), "9999-8888-7777-6666".to_string()); // Conflict
+        ga2.prop2id.insert("P1053".to_string(), "A-1234-5678".to_string()); // New, no conflict
 
         assert!(ga1.merge_from(&ga2).is_ok());
         // Conflicting property: keep existing (higher-priority source)
-        assert_eq!(
-            ga1.prop2id.get("P496"),
-            Some(&"0000-1111-2222-3333".to_string())
-        );
+        assert_eq!(ga1.prop2id.get("P496"), Some(&"0000-1111-2222-3333".to_string()));
         // Non-conflicting property: absorbed
         assert_eq!(ga1.prop2id.get("P1053"), Some(&"A-1234-5678".to_string()));
     }
@@ -882,15 +854,11 @@ mod tests {
 
         let mut ga2 = GenericAuthorInfo::new();
         ga2.wikidata_item = Some("Q42".to_string());
-        ga2.prop2id
-            .insert("P496".to_string(), "0000-0001-2345-6789".to_string());
+        ga2.prop2id.insert("P496".to_string(), "0000-0001-2345-6789".to_string());
 
         assert!(ga1.merge_from(&ga2).is_ok());
         assert_eq!(ga1.wikidata_item, Some("Q42".to_string())); // Adopted from ga2
-        assert_eq!(
-            ga1.prop2id.get("P496"),
-            Some(&"0000-0001-2345-6789".to_string())
-        );
+        assert_eq!(ga1.prop2id.get("P496"), Some(&"0000-0001-2345-6789".to_string()));
     }
 
     #[test]
@@ -923,10 +891,7 @@ mod tests {
 
         let score_exact = ga_ref.compare(&ga_exact);
         let score_partial = ga_ref.compare(&ga_partial);
-        assert!(
-            score_exact > score_partial,
-            "Exact name match must outscore partial"
-        );
+        assert!(score_exact > score_partial, "Exact name match must outscore partial");
         // 101 (2 words × 50 + 1 bonus) vs 50 (1 word match, no bonus)
         assert_eq!(score_exact, SCORE_NAME_MATCH * 2 + 1);
         assert_eq!(score_partial, SCORE_NAME_MATCH);
@@ -934,8 +899,8 @@ mod tests {
 
     #[test]
     fn compare_exact_name_bonus_isolated() {
-        // Names under 3 chars don't trigger word-matching but do trigger the exact bonus,
-        // cleanly isolating the +1 effect.
+        // Names under 3 chars don't trigger word-matching but do trigger the exact
+        // bonus, cleanly isolating the +1 effect.
         let mut ga_ref = GenericAuthorInfo::new();
         ga_ref.name = Some("Li".to_string()); // 2-char word: filtered by \w{3,} regex
 
@@ -945,11 +910,7 @@ mod tests {
         let mut ga_different = GenericAuthorInfo::new();
         ga_different.name = Some("Lo".to_string());
 
-        assert_eq!(
-            ga_ref.compare(&ga_same),
-            1,
-            "Only the +1 exact bonus contributes"
-        );
+        assert_eq!(ga_ref.compare(&ga_same), 1, "Only the +1 exact bonus contributes");
         assert_eq!(ga_ref.compare(&ga_different), 0, "No match, no bonus");
     }
 
@@ -997,9 +958,10 @@ mod tests {
 
     #[test]
     fn find_best_match_still_returns_none_for_ambiguous_different_names() {
-        // "Min Wang" vs ["Li Wang", "Min Wang"]: the exact name bonus distinguishes them.
-        // "min" (3 chars) + "wang" (4 chars) → 2-word match = 100, + 1 bonus = 101 for "Min Wang".
-        // "wang" only (1-word match, no bonus) = 50 for "Li Wang".
+        // "Min Wang" vs ["Li Wang", "Min Wang"]: the exact name bonus distinguishes
+        // them. "min" (3 chars) + "wang" (4 chars) → 2-word match = 100, + 1
+        // bonus = 101 for "Min Wang". "wang" only (1-word match, no bonus) = 50
+        // for "Li Wang".
         let mut ga_new = GenericAuthorInfo::new();
         ga_new.name = Some("Min Wang".to_string());
 
@@ -1056,13 +1018,10 @@ mod tests {
     fn has_partial_match_true_for_prop_match() {
         // A matching external ID (score 90) is a strong partial match.
         let mut ga = GenericAuthorInfo::new();
-        ga.prop2id
-            .insert("P496".to_string(), "0000-0001-2345-6789".to_string());
+        ga.prop2id.insert("P496".to_string(), "0000-0001-2345-6789".to_string());
 
         let mut other = GenericAuthorInfo::new();
-        other
-            .prop2id
-            .insert("P496".to_string(), "0000-0001-2345-6789".to_string());
+        other.prop2id.insert("P496".to_string(), "0000-0001-2345-6789".to_string());
 
         assert!(ga.has_partial_match(&[other]));
     }
@@ -1142,60 +1101,46 @@ mod tests {
         GenericAuthorInfo::deduplicate(&mut authors);
         assert_eq!(authors.len(), 1);
         assert_eq!(authors[0].name, Some("John Smith".to_string()));
-        assert!(authors[0]
-            .alternative_names
-            .contains(&"J Smith".to_string()));
+        assert!(authors[0].alternative_names.contains(&"J Smith".to_string()));
     }
 
     #[test]
     fn deduplicate_absorbs_external_ids_from_duplicate() {
-        // The later entry (lower priority) has an ORCID; after dedup it should be on the first.
+        // The later entry (lower priority) has an ORCID; after dedup it should be on
+        // the first.
         let first = GenericAuthorInfo::new_from_name_num("John Smith", 1);
         let mut second = GenericAuthorInfo::new_from_name_num("John Smith", 1);
-        second
-            .prop2id
-            .insert("P496".to_string(), "0000-0001-2345-6789".to_string());
+        second.prop2id.insert("P496".to_string(), "0000-0001-2345-6789".to_string());
 
         let mut authors = vec![first, second];
         GenericAuthorInfo::deduplicate(&mut authors);
         assert_eq!(authors.len(), 1);
-        assert_eq!(
-            authors[0].prop2id.get("P496"),
-            Some(&"0000-0001-2345-6789".to_string())
-        );
+        assert_eq!(authors[0].prop2id.get("P496"), Some(&"0000-0001-2345-6789".to_string()));
     }
 
     #[test]
     fn deduplicate_preserves_first_entry_data() {
         // First entry's data must win; second entry's conflicting data is discarded.
         let mut first = GenericAuthorInfo::new_from_name_num("John Smith", 1);
-        first
-            .prop2id
-            .insert("P496".to_string(), "FIRST-ORCID".to_string());
+        first.prop2id.insert("P496".to_string(), "FIRST-ORCID".to_string());
 
         let mut second = GenericAuthorInfo::new_from_name_num("John Smith", 1);
-        second
-            .prop2id
-            .insert("P496".to_string(), "SECOND-ORCID".to_string()); // Conflict: first wins
+        second.prop2id.insert("P496".to_string(), "SECOND-ORCID".to_string()); // Conflict: first wins
 
         let mut authors = vec![first, second];
         GenericAuthorInfo::deduplicate(&mut authors);
         assert_eq!(authors.len(), 1);
-        assert_eq!(
-            authors[0].prop2id.get("P496"),
-            Some(&"FIRST-ORCID".to_string())
-        );
+        assert_eq!(authors[0].prop2id.get("P496"), Some(&"FIRST-ORCID".to_string()));
     }
 
     #[test]
     fn deduplicate_tolerates_different_list_numbers_when_names_match_strongly() {
-        // Two authors with the same full name but different list numbers (from sources that
-        // disagree on ordering) should be merged; the first entry's list number is kept.
+        // Two authors with the same full name but different list numbers (from sources
+        // that disagree on ordering) should be merged; the first entry's list
+        // number is kept.
         let first = GenericAuthorInfo::new_from_name_num("Heinrich Manske", 1);
         let mut second = GenericAuthorInfo::new_from_name_num("Heinrich Manske", 3); // shifted position
-        second
-            .prop2id
-            .insert("P496".to_string(), "0000-0001-2345-6789".to_string());
+        second.prop2id.insert("P496".to_string(), "0000-0001-2345-6789".to_string());
 
         let mut authors = vec![first.clone(), second];
         GenericAuthorInfo::deduplicate(&mut authors);
@@ -1211,10 +1156,7 @@ mod tests {
         let ga = GenericAuthorInfo::new();
         // Cases from the false-positive Wikidata edit:
         assert_eq!(ga.author_names_match("Bruce Allen", "G. Allen"), 0);
-        assert_eq!(
-            ga.author_names_match("Jonathan Anderson", "S. B. Anderson"),
-            0
-        );
+        assert_eq!(ga.author_names_match("Jonathan Anderson", "S. B. Anderson"), 0);
         assert_eq!(ga.author_names_match("Carl Blair", "D. G. Blair"), 0);
         assert_eq!(ga.author_names_match("R Gustafson", "E. K. Gustafson"), 0);
         assert_eq!(ga.author_names_match("Andrew M. Hopkins", "P. Hopkins"), 0);
@@ -1234,16 +1176,15 @@ mod tests {
     #[test]
     fn author_names_match_no_conflict_when_one_side_fully_matched() {
         let ga = GenericAuthorInfo::new();
-        // "Heinrich Manske" vs "manske heinrich" — all long words match, no remaining parts
-        assert_eq!(
-            ga.author_names_match("Heinrich Manske", "manske heinrich"),
-            2
-        );
+        // "Heinrich Manske" vs "manske heinrich" — all long words match, no remaining
+        // parts
+        assert_eq!(ga.author_names_match("Heinrich Manske", "manske heinrich"), 2);
     }
 
     #[test]
     fn conflicting_initials_prevents_false_match_with_list_number() {
-        // "Bruce Allen"(5) vs "G. Allen"(5): should NOT match even with same list number.
+        // "Bruce Allen"(5) vs "G. Allen"(5): should NOT match even with same list
+        // number.
         let mut ga1 = GenericAuthorInfo::new();
         ga1.name = Some("Bruce Allen".to_string());
         ga1.list_number = Some("5".to_string());
@@ -1362,10 +1303,8 @@ mod tests {
         assert!(!ga1.has_partial_match(&[ga2]));
     }
 
-    /*
-    TODO:
-    fn new_from_statement
-    fn get_or_create_author_item(
-    fn update_author_item(
-    */
+    // TODO:
+    // fn new_from_statement
+    // fn get_or_create_author_item(
+    // fn update_author_item(
 }

--- a/src/identifiers.rs
+++ b/src/identifiers.rs
@@ -1,5 +1,6 @@
-use regex::Regex;
 use std::str::FromStr;
+
+use regex::Regex;
 
 const PROP_PMID: &str = "P698";
 const PROP_PMCID: &str = "P932";
@@ -33,17 +34,13 @@ impl FromStr for IdProp {
 
 impl std::fmt::Display for IdProp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                IdProp::PMID => PROP_PMID,
-                IdProp::PMCID => PROP_PMCID,
-                IdProp::DOI => PROP_DOI,
-                IdProp::ARXIV => PROP_ARXIV,
-                IdProp::SemanticScholar => PROP_SEMANTIC_SCHOLAR,
-            }
-        )
+        write!(f, "{}", match self {
+            IdProp::PMID => PROP_PMID,
+            IdProp::PMCID => PROP_PMCID,
+            IdProp::DOI => PROP_DOI,
+            IdProp::ARXIV => PROP_ARXIV,
+            IdProp::SemanticScholar => PROP_SEMANTIC_SCHOLAR,
+        })
     }
 }
 
@@ -67,14 +64,10 @@ pub enum GenericWorkType {
 
 impl std::fmt::Display for GenericWorkType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                GenericWorkType::Property(prop) => prop.to_string(),
-                GenericWorkType::Item => "Item".to_string(),
-            }
-        )
+        write!(f, "{}", match self {
+            GenericWorkType::Property(prop) => prop.to_string(),
+            GenericWorkType::Item => "Item".to_string(),
+        })
     }
 }
 
@@ -88,7 +81,8 @@ impl GenericWorkIdentifier {
     pub fn new_prop(prop: IdProp, id: &str) -> Self {
         let id = match &prop {
             IdProp::DOI => id.to_uppercase(), // DOIs are always uppercase
-            IdProp::SemanticScholar => id.to_lowercase(), // Semantic Scholar IDs are always lowercase
+            IdProp::SemanticScholar => id.to_lowercase(), /* Semantic Scholar IDs are always
+                                                            * lowercase */
             _other => id.to_string(),
         };
         Self {
@@ -109,9 +103,10 @@ impl GenericWorkIdentifier {
         &self.work_type
     }
 
-    /// Parses a free-form identifier string into zero or more `GenericWorkIdentifier`s.
-    /// Recognises DOIs (`xx/yy`), PubMed IDs (digits only) and PMC IDs (`PMCnnn`).
-    /// Q-items are intentionally excluded; callers handle those separately.
+    /// Parses a free-form identifier string into zero or more
+    /// `GenericWorkIdentifier`s. Recognises DOIs (`xx/yy`), PubMed IDs
+    /// (digits only) and PMC IDs (`PMCnnn`). Q-items are intentionally
+    /// excluded; callers handle those separately.
     pub fn parse_ids_from_str(s: &str) -> Vec<Self> {
         lazy_static::lazy_static! {
             static ref RE_DOI:   Regex = Regex::new(r#"^(.+/.+)$"#).expect("RE_DOI");
@@ -132,7 +127,8 @@ impl GenericWorkIdentifier {
     }
 }
 
-/// Returns `true` if `id` consists entirely of ASCII digits (i.e. is a raw PubMed ID).
+/// Returns `true` if `id` consists entirely of ASCII digits (i.e. is a raw
+/// PubMed ID).
 pub fn is_pubmed_id(id: &str) -> bool {
     !id.is_empty() && id.chars().all(|c| c.is_ascii_digit())
 }
@@ -147,10 +143,7 @@ mod tests {
         assert_eq!(IdProp::from_str(PROP_PMCID).unwrap(), IdProp::PMCID);
         assert_eq!(IdProp::from_str(PROP_DOI).unwrap(), IdProp::DOI);
         assert_eq!(IdProp::from_str(PROP_ARXIV).unwrap(), IdProp::ARXIV);
-        assert_eq!(
-            IdProp::from_str(PROP_SEMANTIC_SCHOLAR).unwrap(),
-            IdProp::SemanticScholar
-        );
+        assert_eq!(IdProp::from_str(PROP_SEMANTIC_SCHOLAR).unwrap(), IdProp::SemanticScholar);
         assert!(IdProp::from_str("P123").is_err());
     }
 
@@ -216,10 +209,7 @@ mod tests {
         let ids = GenericWorkIdentifier::parse_ids_from_str("10.1234/foobar");
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].id(), "10.1234/FOOBAR"); // DOIs are uppercased
-        assert_eq!(
-            ids[0].work_type(),
-            &GenericWorkType::Property(IdProp::DOI)
-        );
+        assert_eq!(ids[0].work_type(), &GenericWorkType::Property(IdProp::DOI));
     }
 
     #[test]
@@ -227,10 +217,7 @@ mod tests {
         let ids = GenericWorkIdentifier::parse_ids_from_str("12345678");
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].id(), "12345678");
-        assert_eq!(
-            ids[0].work_type(),
-            &GenericWorkType::Property(IdProp::PMID)
-        );
+        assert_eq!(ids[0].work_type(), &GenericWorkType::Property(IdProp::PMID));
     }
 
     #[test]
@@ -238,10 +225,7 @@ mod tests {
         let ids = GenericWorkIdentifier::parse_ids_from_str("PMC12345");
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].id(), "PMC12345");
-        assert_eq!(
-            ids[0].work_type(),
-            &GenericWorkType::Property(IdProp::PMCID)
-        );
+        assert_eq!(ids[0].work_type(), &GenericWorkType::Property(IdProp::PMCID));
     }
 
     #[test]
@@ -267,8 +251,6 @@ mod tests {
     fn parse_ids_from_str_doi_with_slash_only() {
         // A slash-containing string should be recognised as a DOI
         let ids = GenericWorkIdentifier::parse_ids_from_str("a/b");
-        assert!(ids
-            .iter()
-            .any(|id| id.work_type() == &GenericWorkType::Property(IdProp::DOI)));
+        assert!(ids.iter().any(|id| id.work_type() == &GenericWorkType::Property(IdProp::DOI)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate lazy_static;
 
-use wikibase::entity_diff::*;
-use wikibase::*;
+use wikibase::{entity_diff::*, *};
 
 pub mod arxiv2wikidata;
 pub mod author_name_string;
@@ -25,4 +24,3 @@ pub mod sourcemd_config;
 pub mod wikidata_interaction;
 pub mod wikidata_papers;
 pub mod wikidata_string_cache;
-

--- a/src/openalex2wikidata.rs
+++ b/src/openalex2wikidata.rs
@@ -1,10 +1,13 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::{crossref_work_type_to_q, ScientificPublicationAdapter};
-use crate::*;
-use async_trait::async_trait;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+
 use self::identifiers::{GenericWorkIdentifier, GenericWorkType, IdProp};
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::{crossref_work_type_to_q, ScientificPublicationAdapter},
+    *,
+};
 
 pub struct OpenAlex2Wikidata {
     author_cache: HashMap<String, String>,
@@ -81,7 +84,6 @@ impl OpenAlex2Wikidata {
             }
         }
     }
-
 }
 
 #[async_trait(?Send)]
@@ -147,7 +149,7 @@ impl ScientificPublicationAdapter for OpenAlex2Wikidata {
                     }
                 }
                 vec![]
-            }
+            },
             None => vec![],
         }
     }
@@ -179,9 +181,7 @@ impl ScientificPublicationAdapter for OpenAlex2Wikidata {
     fn get_work_issn(&self, publication_id: &str) -> Option<String> {
         let work = self.get_cached_publication_from_id(publication_id)?;
         // Primary location's source has ISSN
-        work["primary_location"]["source"]["issn_l"]
-            .as_str()
-            .map(|s| s.to_string())
+        work["primary_location"]["source"]["issn_l"].as_str().map(|s| s.to_string())
     }
 
     async fn get_author_list(&mut self, publication_id: &str) -> Vec<GenericAuthorInfo> {
@@ -277,9 +277,7 @@ mod tests {
     #[test]
     fn test_get_work_titles() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
         let titles = adapter.get_work_titles("10.1234/TEST");
         assert_eq!(titles.len(), 1);
         assert_eq!(titles[0].value(), "Test Paper Title");
@@ -305,13 +303,8 @@ mod tests {
     #[test]
     fn test_get_work_type() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
-        assert_eq!(
-            adapter.get_work_type("10.1234/TEST"),
-            Some("Q13442814".to_string())
-        );
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
+        assert_eq!(adapter.get_work_type("10.1234/TEST"), Some("Q13442814".to_string()));
     }
 
     #[test]
@@ -320,30 +313,20 @@ mod tests {
         let mut work = make_work();
         work["type_crossref"] = json!("book");
         adapter.work_cache.insert("10.1234/TEST".to_string(), work);
-        assert_eq!(
-            adapter.get_work_type("10.1234/TEST"),
-            Some("Q571".to_string())
-        );
+        assert_eq!(adapter.get_work_type("10.1234/TEST"), Some("Q571".to_string()));
     }
 
     #[test]
     fn test_get_publication_date() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
-        assert_eq!(
-            adapter.get_publication_date("10.1234/TEST"),
-            Some((2023, Some(6), Some(15)))
-        );
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
+        assert_eq!(adapter.get_publication_date("10.1234/TEST"), Some((2023, Some(6), Some(15))));
     }
 
     #[test]
     fn test_get_volume_and_issue() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
         assert_eq!(adapter.get_volume("10.1234/TEST"), Some("42".to_string()));
         assert_eq!(adapter.get_issue("10.1234/TEST"), Some("3".to_string()));
     }
@@ -351,29 +334,19 @@ mod tests {
     #[test]
     fn test_get_work_issn() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
-        assert_eq!(
-            adapter.get_work_issn("10.1234/TEST"),
-            Some("1234-5678".to_string())
-        );
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
+        assert_eq!(adapter.get_work_issn("10.1234/TEST"), Some("1234-5678".to_string()));
     }
 
     #[tokio::test]
     async fn test_get_author_list() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
         let authors = adapter.get_author_list("10.1234/TEST").await;
         assert_eq!(authors.len(), 2);
         assert_eq!(authors[0].name(), Some("Alice Smith"));
         assert_eq!(authors[0].list_number(), Some("1"));
-        assert_eq!(
-            authors[0].prop2id().get("P496"),
-            Some(&"0000-0001-2345-6789".to_string())
-        );
+        assert_eq!(authors[0].prop2id().get("P496"), Some(&"0000-0001-2345-6789".to_string()));
         assert_eq!(authors[1].name(), Some("Bob Jones"));
         assert_eq!(authors[1].list_number(), Some("2"));
         assert!(!authors[1].prop2id().contains_key("P496"));
@@ -391,23 +364,15 @@ mod tests {
     #[test]
     fn test_add_identifiers_from_cached_publication() {
         let mut adapter = OpenAlex2Wikidata::new();
-        adapter
-            .work_cache
-            .insert("10.1234/TEST".to_string(), make_work());
+        adapter.work_cache.insert("10.1234/TEST".to_string(), make_work());
         let mut ret = vec![];
         adapter.add_identifiers_from_cached_publication("10.1234/TEST", &mut ret);
-        assert!(ret.iter().any(
-            |id| *id.work_type() == GenericWorkType::Property(IdProp::DOI)
-                && id.id() == "10.1234/TEST"
-        ));
-        assert!(ret.iter().any(
-            |id| *id.work_type() == GenericWorkType::Property(IdProp::PMID)
-                && id.id() == "12345678"
-        ));
-        assert!(ret.iter().any(
-            |id| *id.work_type() == GenericWorkType::Property(IdProp::PMCID)
-                && id.id() == "PMC9876543"
-        ));
+        assert!(ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::DOI)
+            && id.id() == "10.1234/TEST"));
+        assert!(ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::PMID)
+            && id.id() == "12345678"));
+        assert!(ret.iter().any(|id| *id.work_type() == GenericWorkType::Property(IdProp::PMCID)
+            && id.id() == "PMC9876543"));
     }
 
     #[test]

--- a/src/orcid2wikidata.rs
+++ b/src/orcid2wikidata.rs
@@ -1,12 +1,14 @@
-use self::identifiers::IdProp;
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
+use std::{collections::HashMap, sync::Arc};
+
 use async_trait::async_trait;
 use orcid::*;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::Mutex;
+
+use self::identifiers::IdProp;
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter, *,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct PseudoWork {
@@ -50,16 +52,9 @@ impl Orcid2Wikidata {
     pub async fn get_or_load_author_data(&self, orcid_author_id: &str) -> Option<Author> {
         if !self.author_data.lock().await.contains_key(orcid_author_id) {
             let data = self.client.author(orcid_author_id).await.ok();
-            self.author_data
-                .lock()
-                .await
-                .insert(orcid_author_id.to_string(), data);
+            self.author_data.lock().await.insert(orcid_author_id.to_string(), data);
         }
-        self.author_data
-            .lock()
-            .await
-            .get(orcid_author_id)
-            .and_then(|r| r.clone())
+        self.author_data.lock().await.get(orcid_author_id).and_then(|r| r.clone())
     }
 
     async fn get_author_data(
@@ -76,56 +71,51 @@ impl Orcid2Wikidata {
                     let last_name = j["person"]["name"]["family-name"]["value"].as_str();
                     let given_names = j["person"]["name"]["given-names"]["value"].as_str();
                     match (given_names, last_name) {
-                        (Some(f), Some(l)) => gai.set_name(Some(format!("{} {}", &f, &l))),
+                        (Some(f), Some(l)) => gai.set_name(Some(format!("{} {}", f, l))),
                         (None, Some(l)) => gai.set_name(Some(l.to_string())),
-                        _ => {}
+                        _ => {},
                     }
-                }
+                },
             }
             if let Some(id) = author.orcid_id() {
-                gai.prop2id_mut()
-                    .insert(author_property.to_string(), id.to_string());
+                gai.prop2id_mut().insert(author_property.to_string(), id.to_string());
             }
             let ext_ids = author.external_ids();
             for id in ext_ids {
                 match id.0.as_str() {
                     "ResearcherID" => {
                         gai.prop2id_mut().insert("P1053".to_string(), id.1);
-                    }
+                    },
                     "Researcher ID" => {
                         gai.prop2id_mut().insert("P1053".to_string(), id.1);
-                    }
+                    },
                     "Scopus Author ID" => {
                         gai.prop2id_mut().insert("P1153".to_string(), id.1);
-                    }
+                    },
                     "Scopus ID" => {
                         gai.prop2id_mut().insert("P1153".to_string(), id.1);
-                    }
+                    },
                     "Loop profile" => {
                         gai.prop2id_mut().insert("P2798".to_string(), id.1);
-                    }
+                    },
                     "SciProfiles" => {
                         gai.prop2id_mut().insert("P8159".to_string(), id.1);
-                    }
+                    },
                     "GitHub" => {
                         gai.prop2id_mut().insert("P2037".to_string(), id.1);
-                    }
+                    },
                     "Ciência ID" => {
                         gai.prop2id_mut().insert("P7893".to_string(), id.1);
-                    }
+                    },
                     // "Researcher Name Resolver ID" => {
                     //     gai.prop2id.insert("P9776".to_string(), id.1);
                     // }
                     "ISNI" => {
-                        gai.prop2id_mut()
-                            .insert("P213".to_string(), id.1.replace("-", ""));
-                    }
+                        gai.prop2id_mut().insert("P213".to_string(), id.1.replace("-", ""));
+                    },
                     other => {
-                        self.warn(&format!(
-                            "orcid2wikidata: Unknown ID '{}':'{}'",
-                            &other, &id.1
-                        ));
-                    }
+                        self.warn(&format!("orcid2wikidata: Unknown ID '{}':'{}'", other, id.1));
+                    },
                 }
             }
             return Some(gai);
@@ -185,11 +175,7 @@ impl ScientificPublicationAdapter for Orcid2Wikidata {
             let future = self.get_author_data(orcid_author_id, &author_property);
             futures.push(future);
         }
-        futures::future::join_all(futures)
-            .await
-            .into_iter()
-            .flatten()
-            .collect()
+        futures::future::join_all(futures).await.into_iter().flatten().collect()
     }
 }
 

--- a/src/pmc2wikidata.rs
+++ b/src/pmc2wikidata.rs
@@ -1,20 +1,20 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use regex::Regex;
 use reqwest;
-use std::collections::HashMap;
 
 use self::identifiers::{is_pubmed_id, GenericWorkIdentifier, GenericWorkType, IdProp};
-//use wikibase::mediawiki::api::Api;
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter, *,
+};
+// use wikibase::mediawiki::api::Api;
 
-/*
-Examples:
-https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:13777676%20AND%20SRC:MED&resulttype=core&format=json (no PMCID)
-https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:17246615%20AND%20SRC:MED&resulttype=core&format=json (with PMCID)
-https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=PMC1201091&resulttype=core&format=json (same as line above)
-*/
+// Examples:
+// https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:13777676%20AND%20SRC:MED&resulttype=core&format=json (no PMCID)
+// https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=EXT_ID:17246615%20AND%20SRC:MED&resulttype=core&format=json (with PMCID)
+// https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=PMC1201091&resulttype=core&format=json (same as line above)
 
 #[derive(Debug, Clone, Default)]
 pub struct PMC2Wikidata {
@@ -44,7 +44,7 @@ impl PMC2Wikidata {
                             publication_id = pmc_id.to_string()
                         }
                         self.work_cache.insert(publication_id.clone(), json.clone());
-                    }
+                    },
                     None => return None,
                 }
             }
@@ -73,7 +73,7 @@ impl PMC2Wikidata {
                 match results.first() {
                     Some(json) => {
                         self.work_cache.insert(pmc_id.to_string(), json.clone());
-                    }
+                    },
                     None => return None,
                 }
             }
@@ -176,7 +176,7 @@ impl ScientificPublicationAdapter for PMC2Wikidata {
                         Some(pmid) => self.publication_id_from_pubmed(&pmid).await,
                         None => None,
                     };
-                }
+                },
             };
         self.publication_id_from_pmcid(&pmcid).await
     }
@@ -237,14 +237,14 @@ impl ScientificPublicationAdapter for PMC2Wikidata {
                         {
                             self.add_identifiers_from_cached_publication(&publication_id, &mut ret);
                         }
-                    }
+                    },
                     IdProp::PMCID => {
                         if let Some(publication_id) = self.publication_id_from_pmcid(id.id()).await
                         {
                             self.add_identifiers_from_cached_publication(&publication_id, &mut ret);
                         }
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
         }
@@ -281,8 +281,9 @@ impl ScientificPublicationAdapter for PMC2Wikidata {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     fn make_pmc(id: &str, work: serde_json::Value) -> PMC2Wikidata {
         let mut pmc = PMC2Wikidata::new();
@@ -321,7 +322,7 @@ mod tests {
         let pmc = PMC2Wikidata::new();
         assert!(!pmc.is_pmcid("12345"));
         assert!(!pmc.is_pmcid("pmc123")); // lowercase
-        assert!(!pmc.is_pmcid("PMC"));    // no digits
+        assert!(!pmc.is_pmcid("PMC")); // no digits
         assert!(!pmc.is_pmcid(""));
         assert!(!pmc.is_pmcid("PMC12 34"));
     }
@@ -331,10 +332,7 @@ mod tests {
     #[test]
     fn publication_id_for_statement_strips_pmc_prefix() {
         let pmc = PMC2Wikidata::new();
-        assert_eq!(
-            pmc.publication_id_for_statement("PMC12345"),
-            Some("12345".to_string())
-        );
+        assert_eq!(pmc.publication_id_for_statement("PMC12345"), Some("12345".to_string()));
     }
 
     #[test]
@@ -402,10 +400,7 @@ mod tests {
 
     #[test]
     fn get_volume_extracts_from_journal_info() {
-        let pmc = make_pmc(
-            "PMC1",
-            json!({"journalInfo": {"volume": "12"}}),
-        );
+        let pmc = make_pmc("PMC1", json!({"journalInfo": {"volume": "12"}}));
         assert_eq!(pmc.get_volume("PMC1"), Some("12".to_string()));
     }
 
@@ -417,19 +412,13 @@ mod tests {
 
     #[test]
     fn get_issue_extracts_from_journal_info() {
-        let pmc = make_pmc(
-            "PMC1",
-            json!({"journalInfo": {"issue": "3"}}),
-        );
+        let pmc = make_pmc("PMC1", json!({"journalInfo": {"issue": "3"}}));
         assert_eq!(pmc.get_issue("PMC1"), Some("3".to_string()));
     }
 
     #[test]
     fn get_work_issn_extracts_from_journal_info() {
-        let pmc = make_pmc(
-            "PMC1",
-            json!({"journalInfo": {"journal": {"issn": "1234-5678"}}}),
-        );
+        let pmc = make_pmc("PMC1", json!({"journalInfo": {"journal": {"issn": "1234-5678"}}}));
         assert_eq!(pmc.get_work_issn("PMC1"), Some("1234-5678".to_string()));
     }
 
@@ -443,10 +432,7 @@ mod tests {
 
     #[test]
     fn get_publication_date_year_only() {
-        let pmc = make_pmc(
-            "PMC1",
-            json!({"journalInfo": {"yearOfPublication": 2021}}),
-        );
+        let pmc = make_pmc("PMC1", json!({"journalInfo": {"yearOfPublication": 2021}}));
         assert_eq!(pmc.get_publication_date("PMC1"), Some((2021, None, None)));
     }
 
@@ -456,10 +442,7 @@ mod tests {
             "PMC1",
             json!({"journalInfo": {"yearOfPublication": 2021, "monthOfPublication": 6}}),
         );
-        assert_eq!(
-            pmc.get_publication_date("PMC1"),
-            Some((2021, Some(6), None))
-        );
+        assert_eq!(pmc.get_publication_date("PMC1"), Some((2021, Some(6), None)));
     }
 
     #[test]
@@ -472,10 +455,7 @@ mod tests {
                 "dayOfPublication": 15
             }}),
         );
-        assert_eq!(
-            pmc.get_publication_date("PMC1"),
-            Some((2021, Some(3), Some(15)))
-        );
+        assert_eq!(pmc.get_publication_date("PMC1"), Some((2021, Some(3), Some(15))));
     }
 
     #[test]

--- a/src/pubmed2wikidata.rs
+++ b/src/pubmed2wikidata.rs
@@ -1,10 +1,14 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::identifiers::{is_pubmed_id, GenericWorkIdentifier, GenericWorkType, IdProp};
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use pubmed::*;
-use std::collections::HashMap;
+
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    identifiers::{is_pubmed_id, GenericWorkIdentifier, GenericWorkType, IdProp},
+    scientific_publication_adapter::ScientificPublicationAdapter,
+    *,
+};
 
 #[derive(Debug, Clone)]
 pub struct Pubmed2Wikidata {
@@ -35,19 +39,13 @@ impl Pubmed2Wikidata {
     }
 
     fn get_author_name_string(&self, author: &Author) -> Option<String> {
-        let mut ret: String = match &author.last_name {
-            Some(s) => s.to_string(),
-            None => return None,
+        let last_name = author.last_name.as_deref()?;
+        let first_part = author.fore_name.as_deref().or(author.initials.as_deref());
+        let full_name = match first_part {
+            Some(first) => format!("{first} {last_name}"),
+            None => last_name.to_string(),
         };
-        match &author.fore_name {
-            Some(s) => ret = s.to_string() + " " + &ret,
-            None => {
-                if let Some(s) = &author.initials {
-                    ret = s.to_string() + " " + &ret
-                }
-            }
-        }
-        Some(self.sanitize_author_name(&ret))
+        Some(self.sanitize_author_name(&full_name))
     }
 
     async fn publication_id_from_pubmed(&mut self, publication_id: &str) -> Option<String> {
@@ -66,11 +64,7 @@ impl Pubmed2Wikidata {
         let query = doi.to_string();
         let work_ids: Vec<u64> = match self.query_cache.get(&query) {
             Some(work_ids) => work_ids.clone(),
-            None => self
-                .client
-                .article_ids_from_query(&query, 10)
-                .await
-                .unwrap_or_default(),
+            None => self.client.article_ids_from_query(&query, 10).await.unwrap_or_default(),
         };
         self.query_cache.insert(query, work_ids.clone());
         for publication_id in &work_ids {
@@ -80,8 +74,8 @@ impl Pubmed2Wikidata {
                 match self.client.article(*publication_id).await {
                     Ok(work) => {
                         e.insert(work);
-                    }
-                    Err(e) => self.warn(&format!("pubmed::publication_ids_from_doi: {:?}", &e)),
+                    },
+                    Err(e) => self.warn(&format!("pubmed::publication_ids_from_doi: {:?}", e)),
                 }
             }
         }
@@ -92,10 +86,7 @@ impl Pubmed2Wikidata {
         work_ids
             .iter()
             .map(|s| s.to_string())
-            .filter(|pub_id| {
-                self.get_dois_from_cached_publication(pub_id)
-                    .contains(&doi_upper)
-            })
+            .filter(|pub_id| self.get_dois_from_cached_publication(pub_id).contains(&doi_upper))
             .collect()
     }
 
@@ -171,9 +162,9 @@ impl Pubmed2Wikidata {
                         "doi" => ret.push(GenericWorkIdentifier::new_prop(IdProp::DOI, id)),
                         other => {
                             self.warn(&format!("pubmed2wikidata::get_identifier_list unknown paper ID type '{other}'"));
-                        }
+                        },
                     }
-                }
+                },
                 _ => continue,
             }
         }
@@ -218,9 +209,7 @@ impl ScientificPublicationAdapter for Pubmed2Wikidata {
     }
 
     fn get_work_issn(&self, publication_id: &str) -> Option<String> {
-        let work = self
-            .get_cached_publication_from_id(publication_id)?
-            .to_owned();
+        let work = self.get_cached_publication_from_id(publication_id)?.to_owned();
         let medline_citation = work.medline_citation?.to_owned();
         let article = medline_citation.article?.to_owned();
         let journal = article.journal?.to_owned();
@@ -241,13 +230,13 @@ impl ScientificPublicationAdapter for Pubmed2Wikidata {
                         {
                             self.add_identifiers_from_cached_publication(&publication_id, &mut ret);
                         }
-                    }
+                    },
                     IdProp::DOI => {
                         for publication_id in self.publication_ids_from_doi(id.id()).await {
                             self.add_identifiers_from_cached_publication(&publication_id, &mut ret);
                         }
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
         }
@@ -377,8 +366,7 @@ impl ScientificPublicationAdapter for Pubmed2Wikidata {
             return ret;
         }
 
-        let mut list_num = 1;
-        for author in &author_list.authors {
+        for (list_num, author) in (1..).zip(author_list.authors.iter()) {
             let mut prop2id: HashMap<String, String> = HashMap::new();
             for aid in &author.identifiers {
                 if let (Some(source), Some(id)) = (&aid.source, &aid.id) {
@@ -388,7 +376,7 @@ impl ScientificPublicationAdapter for Pubmed2Wikidata {
                             if let Some(id) = id.split('/').next_back() {
                                 prop2id.insert("P496".to_string(), id.to_string());
                             }
-                        }
+                        },
                         other => self.warn(&format!("Unknown author source: {other}:{id}")),
                     }
                 }
@@ -398,7 +386,6 @@ impl ScientificPublicationAdapter for Pubmed2Wikidata {
             gai.set_list_number(Some(list_num.to_string()));
             *gai.prop2id_mut() = prop2id;
             ret.push(gai);
-            list_num += 1;
         }
 
         ret
@@ -430,10 +417,7 @@ mod tests {
         PubmedArticle {
             medline_citation: Some(MedlineCitation {
                 pmid,
-                article: Some(Article {
-                    e_location_ids,
-                    ..Article::new()
-                }),
+                article: Some(Article { e_location_ids, ..Article::new() }),
                 ..MedlineCitation::new()
             }),
             pubmed_data: Some(PubmedData {
@@ -448,10 +432,8 @@ mod tests {
     #[test]
     fn test_get_dois_from_cached_publication_with_doi() {
         let mut pm = Pubmed2Wikidata::new();
-        pm.work_cache.insert(
-            "12345".to_string(),
-            make_article(12345, Some("10.1234/test")),
-        );
+        pm.work_cache
+            .insert("12345".to_string(), make_article(12345, Some("10.1234/test")));
         let dois = pm.get_dois_from_cached_publication("12345");
         assert!(dois.contains(&"10.1234/TEST".to_string()));
     }
@@ -459,8 +441,7 @@ mod tests {
     #[test]
     fn test_get_dois_from_cached_publication_no_doi() {
         let mut pm = Pubmed2Wikidata::new();
-        pm.work_cache
-            .insert("99999".to_string(), make_article(99999, None));
+        pm.work_cache.insert("99999".to_string(), make_article(99999, None));
         let dois = pm.get_dois_from_cached_publication("99999");
         assert!(dois.is_empty());
     }
@@ -481,14 +462,11 @@ mod tests {
 
         let mut pm = Pubmed2Wikidata::new();
         // Pre-populate query_cache so no network call is made
-        pm.query_cache
-            .insert(target_doi.to_string(), vec![11111, 22222]);
+        pm.query_cache.insert(target_doi.to_string(), vec![11111, 22222]);
         // Pre-populate work_cache: article 11111 has the correct DOI,
         // article 22222 has a different DOI
-        pm.work_cache
-            .insert("11111".to_string(), make_article(11111, Some(target_doi)));
-        pm.work_cache
-            .insert("22222".to_string(), make_article(22222, Some(wrong_doi)));
+        pm.work_cache.insert("11111".to_string(), make_article(11111, Some(target_doi)));
+        pm.work_cache.insert("22222".to_string(), make_article(22222, Some(wrong_doi)));
 
         let result = pm.publication_ids_from_doi(target_doi).await;
         assert_eq!(result, vec!["11111".to_string()]);
@@ -501,10 +479,8 @@ mod tests {
 
         let mut pm = Pubmed2Wikidata::new();
         pm.query_cache.insert(target_doi.to_string(), vec![33333]);
-        pm.work_cache.insert(
-            "33333".to_string(),
-            make_article(33333, Some("10.9999/different")),
-        );
+        pm.work_cache
+            .insert("33333".to_string(), make_article(33333, Some("10.9999/different")));
 
         let result = pm.publication_ids_from_doi(target_doi).await;
         assert!(result.is_empty());
@@ -538,20 +514,17 @@ mod tests {
     #[test]
     fn get_work_titles_returns_english_title() {
         let mut pm = Pubmed2Wikidata::new();
-        pm.work_cache.insert(
-            "1".to_string(),
-            PubmedArticle {
-                medline_citation: Some(MedlineCitation {
-                    pmid: 1,
-                    article: Some(Article {
-                        title: Some("A Test Paper Title".to_string()),
-                        ..Article::new()
-                    }),
-                    ..MedlineCitation::new()
+        pm.work_cache.insert("1".to_string(), PubmedArticle {
+            medline_citation: Some(MedlineCitation {
+                pmid: 1,
+                article: Some(Article {
+                    title: Some("A Test Paper Title".to_string()),
+                    ..Article::new()
                 }),
-                pubmed_data: None,
-            },
-        );
+                ..MedlineCitation::new()
+            }),
+            pubmed_data: None,
+        });
         let titles = pm.get_work_titles("1");
         assert_eq!(titles.len(), 1);
         assert_eq!(titles[0].value(), "A Test Paper Title");
@@ -574,23 +547,20 @@ mod tests {
     #[test]
     fn get_work_issn_extracts_issn() {
         let mut pm = Pubmed2Wikidata::new();
-        pm.work_cache.insert(
-            "3".to_string(),
-            PubmedArticle {
-                medline_citation: Some(MedlineCitation {
-                    pmid: 3,
-                    article: Some(Article {
-                        journal: Some(Journal {
-                            issn: Some("1234-5678".to_string()),
-                            ..Journal::new()
-                        }),
-                        ..Article::new()
+        pm.work_cache.insert("3".to_string(), PubmedArticle {
+            medline_citation: Some(MedlineCitation {
+                pmid: 3,
+                article: Some(Article {
+                    journal: Some(Journal {
+                        issn: Some("1234-5678".to_string()),
+                        ..Journal::new()
                     }),
-                    ..MedlineCitation::new()
+                    ..Article::new()
                 }),
-                pubmed_data: None,
-            },
-        );
+                ..MedlineCitation::new()
+            }),
+            pubmed_data: None,
+        });
         assert_eq!(pm.get_work_issn("3"), Some("1234-5678".to_string()));
     }
 

--- a/src/scientific_publication_adapter.rs
+++ b/src/scientific_publication_adapter.rs
@@ -1,15 +1,16 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::*;
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use regex::Regex;
-use std::collections::HashMap;
 use tokio::sync::OnceCell;
 use wikibase::mediawiki::api::Api;
 
 use self::identifiers::{GenericWorkIdentifier, IdProp};
+use crate::{generic_author_info::GenericAuthorInfo, *};
 
-/// Maps a Crossref/OpenAlex work-type string to a Wikidata Q-item for P31 (instance of).
-/// Both APIs use the same Crossref type vocabulary, so a single function serves both.
+/// Maps a Crossref/OpenAlex work-type string to a Wikidata Q-item for P31
+/// (instance of). Both APIs use the same Crossref type vocabulary, so a single
+/// function serves both.
 pub fn crossref_work_type_to_q(type_: &str) -> Option<&'static str> {
     match type_ {
         "journal-article" => Some("Q13442814"),
@@ -28,7 +29,8 @@ pub fn crossref_work_type_to_q(type_: &str) -> Option<&'static str> {
     }
 }
 
-/// Parses a date string like "2023-01-15" or "2023-01-15T00:00:00Z" into (year, month, day).
+/// Parses a date string like "2023-01-15" or "2023-01-15T00:00:00Z" into (year,
+/// month, day).
 pub fn parse_date(date_str: &str) -> Option<(u32, Option<u8>, Option<u8>)> {
     let date_part = date_str.split('T').next()?;
     let parts: Vec<&str> = date_part.split('-').collect();
@@ -45,13 +47,16 @@ pub trait ScientificPublicationAdapter {
     /// Returns the name of the resource; internal/debugging use only
     fn name(&self) -> &str;
 
-    /// Returns a cache object reference for the author_id => wikidata_item mapping; this is handled automatically
+    /// Returns a cache object reference for the author_id => wikidata_item
+    /// mapping; this is handled automatically
     fn author_cache(&self) -> &HashMap<String, String>;
 
-    /// Returns a mutable cache object reference for the author_id => wikidata_item mapping; this is handled automatically
+    /// Returns a mutable cache object reference for the author_id =>
+    /// wikidata_item mapping; this is handled automatically
     fn author_cache_mut(&mut self) -> &mut HashMap<String, String>;
 
-    /// Tries to determine the publication ID of the resource, from a Wikidata item
+    /// Tries to determine the publication ID of the resource, from a Wikidata
+    /// item
     async fn publication_id_from_item(&mut self, item: &Entity) -> Option<String> {
         match self.publication_property() {
             Some(self_prop) => match self.get_external_identifier_from_item(item, &self_prop) {
@@ -72,13 +77,16 @@ pub trait ScientificPublicationAdapter {
         // Do nothing
     }
 
-    /// Adds/updates "special" statements of an item from the resource, given the publication ID.
-    /// Many common statements, title, aliases etc are automatically handeled via `update_statements_for_publication_id_default`
+    /// Adds/updates "special" statements of an item from the resource, given
+    /// the publication ID. Many common statements, title, aliases etc are
+    /// automatically handeled via
+    /// `update_statements_for_publication_id_default`
     async fn update_statements_for_publication_id(&self, publication_id: &str, item: &mut Entity);
 
     // You should implement these yourself, where applicable
 
-    /// Returns a list of the authors, if available, with list number, name, catalog-specific author ID, and WIkidata ID, as available
+    /// Returns a list of the authors, if available, with list number, name,
+    /// catalog-specific author ID, and WIkidata ID, as available
     async fn get_author_list(&mut self, _publication_id: &str) -> Vec<GenericAuthorInfo> {
         vec![]
     }
@@ -111,17 +119,20 @@ pub trait ScientificPublicationAdapter {
         None
     }
 
-    /// Returns the property for an author ID of the resource as a `String`, e.g. P4012 for Semantic Scholar
+    /// Returns the property for an author ID of the resource as a `String`,
+    /// e.g. P4012 for Semantic Scholar
     fn author_property(&self) -> Option<String> {
         None
     }
 
-    /// Returns the property for a publication ID of the resource as a `String`, e.g. P4011 for Semantic Scholar
+    /// Returns the property for a publication ID of the resource as a `String`,
+    /// e.g. P4011 for Semantic Scholar
     fn publication_property(&self) -> Option<IdProp> {
         None
     }
 
-    /// Returns the property for a topic ID of the resource as a `String`, e.g. P6611 for Semantic Scholar
+    /// Returns the property for a topic ID of the resource as a `String`, e.g.
+    /// P6611 for Semantic Scholar
     fn topic_property(&self) -> Option<String> {
         None
     }
@@ -137,7 +148,8 @@ pub trait ScientificPublicationAdapter {
         None
     }
 
-    // For a publication ID, return all known titles as a `Vec<LocaleString>`, main title first (per language)
+    // For a publication ID, return all known titles as a `Vec<LocaleString>`, main
+    // title first (per language)
     fn get_work_titles(&self, _publication_id: &str) -> Vec<LocaleString> {
         vec![]
     }
@@ -163,7 +175,8 @@ pub trait ScientificPublicationAdapter {
     }
 
     /// Strips HTML/XML tags from a string, preserving text content.
-    /// E.g. "Correction: <i>Accidental aspiration</i>" → "Correction: Accidental aspiration"
+    /// E.g. "Correction: <i>Accidental aspiration</i>" → "Correction:
+    /// Accidental aspiration"
     fn strip_html_tags(&self, s: &str) -> String {
         lazy_static! {
             static ref RE_HTML: Regex =
@@ -182,13 +195,11 @@ pub trait ScientificPublicationAdapter {
     ) {
         self.update_work_item_with_title(publication_id, item);
         self.update_work_item_with_property(publication_id, item);
-        self.update_work_item_with_journal(publication_id, item)
-            .await;
+        self.update_work_item_with_journal(publication_id, item).await;
         self.update_work_item_with_volume(publication_id, item);
         self.update_work_item_with_issue(publication_id, item);
         self.update_work_item_with_publication_date(publication_id, item);
-        self.update_work_item_with_language(publication_id, item)
-            .await;
+        self.update_work_item_with_language(publication_id, item).await;
     }
 
     async fn update_work_item_with_language(&self, publication_id: &str, item: &mut Entity) {
@@ -271,8 +282,10 @@ pub trait ScientificPublicationAdapter {
             let mut titles = titles.clone();
             // Add title
             match item.label_in_locale(language) {
-                Some(t) => titles.retain(|x| !self.titles_are_equal(x, t)), // Title exists, remove from title list
-                None => item.set_label(LocaleString::new("en", &titles.swap_remove(0))), // No title, add and remove from title list
+                Some(t) => titles.retain(|x| !self.titles_are_equal(x, t)), /* Title exists,
+                                                                              * remove from title
+                                                                              * list */
+                None => item.set_label(LocaleString::new("en", &titles.swap_remove(0))), /* No title, add and remove from title list */
             }
 
             // Add other potential titles as aliases
@@ -281,8 +294,8 @@ pub trait ScientificPublicationAdapter {
             //     .iter()
             //     .filter(|t| !self.titles_are_equal(t, &main_title))
             //     .for_each(|t| {
-            //         item.add_alias(LocaleString::new(language.to_string(), t.to_string()))
-            //     });
+            //         item.add_alias(LocaleString::new(language.to_string(),
+            // t.to_string()))     });
 
             // Add P1476 (title)
             if !item.has_claims_with_property("P1476") {
@@ -308,7 +321,7 @@ pub trait ScientificPublicationAdapter {
             return;
         }
         if let Some(_issn) = self.get_work_issn(publication_id) {
-            let r = Some("".to_string()); //cache.issn2q(&issn).await;
+            let r = Some("".to_string()); // cache.issn2q(&issn).await;
             if let Some(q) = r {
                 item.add_claim(Statement::new_normal(
                     Snak::new_item("P1433", &q),
@@ -349,11 +362,7 @@ pub trait ScientificPublicationAdapter {
             None => ("-01".to_string(), precision),
         };
         let time = format!("+{year}{month_str}{day_str}T00:00:00Z");
-        Statement::new_normal(
-            Snak::new_time(property, time, precision),
-            vec![],
-            self.reference(),
-        )
+        Statement::new_normal(Snak::new_time(property, time, precision), vec![], self.reference())
     }
 
     fn get_external_identifier_from_item(
@@ -367,17 +376,14 @@ pub trait ScientificPublicationAdapter {
                 claim.main_snak().property() == property.as_str()
                     && *claim.main_snak().snak_type() == SnakType::Value
             })
-            .find_map(
-                |claim| match claim.main_snak().data_value().as_ref()?.value() {
-                    Value::StringValue(s) => Some(s.to_string()),
-                    _ => None,
-                },
-            )
+            .find_map(|claim| match claim.main_snak().data_value().as_ref()?.value() {
+                Value::StringValue(s) => Some(s.to_string()),
+                _ => None,
+            })
     }
 
     fn set_author_cache_entry(&mut self, catalog_author_id: &str, q: &str) {
-        self.author_cache_mut()
-            .insert(catalog_author_id.to_string(), q.to_string());
+        self.author_cache_mut().insert(catalog_author_id.to_string(), q.to_string());
     }
 
     fn get_author_item_from_cache(&self, catalog_author_id: &str) -> Option<&String> {
@@ -432,10 +438,7 @@ mod tests {
     impl TestAdapter {
         fn with_titles(titles: Vec<&str>) -> Self {
             Self {
-                titles: titles
-                    .into_iter()
-                    .map(|t| LocaleString::new("en", t))
-                    .collect(),
+                titles: titles.into_iter().map(|t| LocaleString::new("en", t)).collect(),
                 author_cache: HashMap::new(),
             }
         }
@@ -488,14 +491,8 @@ mod tests {
     #[test]
     fn strip_html_tags_handles_sub_sup() {
         let adapter = TestAdapter::with_titles(vec![]);
-        assert_eq!(
-            adapter.strip_html_tags("H<sub>2</sub>O and CO<sub>2</sub>"),
-            "H2O and CO2"
-        );
-        assert_eq!(
-            adapter.strip_html_tags("x<sup>2</sup> + y<sup>2</sup>"),
-            "x2 + y2"
-        );
+        assert_eq!(adapter.strip_html_tags("H<sub>2</sub>O and CO<sub>2</sub>"), "H2O and CO2");
+        assert_eq!(adapter.strip_html_tags("x<sup>2</sup> + y<sup>2</sup>"), "x2 + y2");
     }
 
     #[test]

--- a/src/semanticscholar2wikidata.rs
+++ b/src/semanticscholar2wikidata.rs
@@ -1,11 +1,13 @@
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::*;
-use async_trait::async_trait;
-use semanticscholar::*;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+use semanticscholar::*;
+
 use self::identifiers::{GenericWorkIdentifier, GenericWorkType, IdProp};
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter, *,
+};
 
 pub struct Semanticscholar2Wikidata {
     author_cache: HashMap<String, String>,
@@ -68,18 +70,16 @@ impl Semanticscholar2Wikidata {
             ret.push(GenericWorkIdentifier::new_prop(IdProp::DOI, id));
         }
 
-        /*
-        This works, but might somehow merge separate items for "reviewed publication" and arxiv version
-        match &work.arxiv_id {
-            Some(id) => {
-                ret.push(GenericWorkIdentifier {
-                    work_type: GenericWorkType::Property(PROP_ARXIV.to_string()),
-                    id: id.clone(),
-                });
-            }
-            None => {}
-        }
-        */
+        // This works, but might somehow merge separate items for "reviewed
+        // publication" and arxiv version match &work.arxiv_id {
+        // Some(id) => {
+        // ret.push(GenericWorkIdentifier {
+        // work_type: GenericWorkType::Property(PROP_ARXIV.to_string()),
+        // id: id.clone(),
+        // });
+        // }
+        // None => {}
+        // }
     }
 }
 
@@ -97,18 +97,16 @@ impl ScientificPublicationAdapter for Semanticscholar2Wikidata {
         Some(IdProp::SemanticScholar)
     }
 
-    /*
     // TODO load direct from SS via own ID
-    fn publication_id_from_item(&mut self, item: &Entity) -> Option<String> {
-        let publication_id = match self
-            .get_external_identifier_from_item(item, &self.publication_property().unwrap())
-        {
-            Some(s) => s,
-            None => return None,
-        };
-        self.publication_id_from_pubmed(&publication_id)
-    }
-    */
+    // fn publication_id_from_item(&mut self, item: &Entity) -> Option<String> {
+    // let publication_id = match self
+    // .get_external_identifier_from_item(item,
+    // &self.publication_property().unwrap()) {
+    // Some(s) => s,
+    // None => return None,
+    // };
+    // self.publication_id_from_pubmed(&publication_id)
+    // }
 
     fn topic_property(&self) -> Option<String> {
         Some("P6611".to_string())
@@ -196,9 +194,7 @@ impl ScientificPublicationAdapter for Semanticscholar2Wikidata {
             entry.set_name(author.name.clone());
             entry.set_list_number(Some((num + 1).to_string()));
             if let Some(id) = &author.author_id {
-                entry
-                    .prop2id_mut()
-                    .insert(author_property.to_owned(), id.to_string());
+                entry.prop2id_mut().insert(author_property.to_owned(), id.to_string());
             }
             ret.push(entry);
         }
@@ -291,10 +287,9 @@ mod tests {
         let mut ss = make_ss("abc123", make_work(None, None, None));
         let mut ret = vec![];
         ss.add_identifiers_from_cached_publication("abc123", &mut ret);
-        assert!(ret
-            .iter()
-            .any(|id| id.work_type() == &identifiers::GenericWorkType::Property(IdProp::SemanticScholar)
-                && id.id() == "abc123"));
+        assert!(ret.iter().any(|id| id.work_type()
+            == &identifiers::GenericWorkType::Property(IdProp::SemanticScholar)
+            && id.id() == "abc123"));
     }
 
     #[test]
@@ -366,10 +361,7 @@ mod tests {
         let mut ss = make_ss("abc123", work);
         let authors = ss.get_author_list("abc123").await;
         assert_eq!(authors.len(), 1);
-        assert_eq!(
-            authors[0].prop2id().get("P4012"),
-            Some(&"ss_auth_42".to_string())
-        );
+        assert_eq!(authors[0].prop2id().get("P4012"), Some(&"ss_auth_42".to_string()));
     }
 
     #[tokio::test]

--- a/src/sourcemd_bot.rs
+++ b/src/sourcemd_bot.rs
@@ -1,25 +1,28 @@
-use crate::arxiv2wikidata::Arxiv2Wikidata;
-use crate::crossref2wikidata::Crossref2Wikidata;
-use crate::datacite2wikidata::DataCite2Wikidata;
-use crate::europepmc2wikidata::EuropePMC2Wikidata;
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::identifiers::{GenericWorkIdentifier, IdProp};
-use crate::openalex2wikidata::OpenAlex2Wikidata;
-use crate::orcid2wikidata::Orcid2Wikidata;
-use crate::pmc2wikidata::PMC2Wikidata;
-use crate::pubmed2wikidata::Pubmed2Wikidata;
-use crate::semanticscholar2wikidata::Semanticscholar2Wikidata;
-use crate::sourcemd_command::SourceMDcommand;
-use crate::sourcemd_config::SourceMD;
-use crate::wikidata_papers::WikidataPapers;
-use crate::wikidata_string_cache::WikidataStringCache;
-use crate::*;
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use regex::Regex;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use self::sourcemd_command::SourceMDcommandMode;
+use crate::{
+    arxiv2wikidata::Arxiv2Wikidata,
+    crossref2wikidata::Crossref2Wikidata,
+    datacite2wikidata::DataCite2Wikidata,
+    europepmc2wikidata::EuropePMC2Wikidata,
+    generic_author_info::GenericAuthorInfo,
+    identifiers::{GenericWorkIdentifier, IdProp},
+    openalex2wikidata::OpenAlex2Wikidata,
+    orcid2wikidata::Orcid2Wikidata,
+    pmc2wikidata::PMC2Wikidata,
+    pubmed2wikidata::Pubmed2Wikidata,
+    semanticscholar2wikidata::Semanticscholar2Wikidata,
+    sourcemd_command::SourceMDcommand,
+    sourcemd_config::SourceMD,
+    wikidata_papers::WikidataPapers,
+    wikidata_string_cache::WikidataStringCache,
+    *,
+};
 
 #[derive(Debug, Clone)]
 pub struct SourceMDbot {
@@ -34,26 +37,20 @@ impl SourceMDbot {
         cache: Arc<WikidataStringCache>,
         batch_id: i64,
     ) -> Result<Self> {
-        let ret = Self {
-            config,
-            batch_id,
-            cache,
-        };
+        let ret = Self { config, batch_id, cache };
         ret.start().await?;
         Ok(ret)
     }
 
     pub async fn start(&self) -> Result<()> {
         let config = self.config.read().await;
-        config
-            .restart_batch(self.batch_id)
-            .ok_or(anyhow!("Can't (re)start batch"))?;
+        config.restart_batch(self.batch_id).ok_or(anyhow!("Can't (re)start batch"))?;
         config.set_batch_running(self.batch_id).await;
         Ok(())
     }
 
     pub async fn run(&self) -> Result<bool> {
-        //Check if batch is still valid (STOP etc)
+        // Check if batch is still valid (STOP etc)
         let command = self.get_next_command().await;
         let mut command = match command {
             Some(c) => c,
@@ -65,11 +62,10 @@ impl SourceMDbot {
                     .await
                     .ok_or(anyhow!("Can't set batch as stopped"))?;
                 return Ok(false);
-            }
+            },
         };
 
-        self.set_command_status("RUNNING", None, &mut command)
-            .await?;
+        self.set_command_status("RUNNING", None, &mut command).await?;
         match self.execute_command(&mut command).await {
             Ok(b) => {
                 if b {
@@ -78,12 +74,11 @@ impl SourceMDbot {
                     self.set_command_status("DUNNO", None, &mut command).await?;
                 }
                 Ok(b)
-            }
+            },
             Err(e) => {
-                self.set_command_status("FAILED", Some(&e.to_string()), &mut command)
-                    .await?;
+                self.set_command_status("FAILED", Some(&e.to_string()), &mut command).await?;
                 Err(e)
-            }
+            },
         }
     }
 
@@ -98,14 +93,10 @@ impl SourceMDbot {
                 } else {
                     self.process_author_metadata(command).await
                 }
-            }
+            },
             SourceMDcommandMode::EditPaperForOrcidAuthor => Ok(false), // TODO
             SourceMDcommandMode::CreateBookFromIsbn => Ok(false),      // TODO
-            other => Err(anyhow!(
-                "Unrecognized command '{}' on command #{}",
-                &other,
-                &command.id
-            )),
+            other => Err(anyhow!("Unrecognized command '{}' on command #{}", other, command.id)),
         }
     }
 
@@ -121,9 +112,7 @@ impl SourceMDbot {
         if RE_WD.is_match(identifier) {
             author.set_wikidata_item(Some(identifier.to_owned()));
         } else if RE_ORCID.is_match(identifier) {
-            author
-                .prop2id_mut()
-                .insert("P496".to_string(), identifier.to_owned());
+            author.prop2id_mut().insert("P496".to_string(), identifier.to_owned());
             author = author
                 .get_or_create_author_item(
                     self.config.read().await.mw_api(),
@@ -132,18 +121,12 @@ impl SourceMDbot {
                 )
                 .await
         } else {
-            return Err(anyhow!(
-                "Not a Wikidata item, nor an ORCID ID {}",
-                identifier
-            ));
+            return Err(anyhow!("Not a Wikidata item, nor an ORCID ID {}", identifier));
         }
 
         // Paranoia
         if author.wikidata_item().is_none() {
-            return Err(anyhow!(
-                "Failed to get/create author item for {}",
-                identifier
-            ));
+            return Err(anyhow!("Failed to get/create author item for {}", identifier));
         }
 
         Ok(author)
@@ -159,8 +142,7 @@ impl SourceMDbot {
             self.batch_id, self.batch_id, command.serial_number
         )));
         let config = self.config.read().await;
-        wdp.update_author_items(&vec![author], config.mw_api())
-            .await;
+        wdp.update_author_items(&vec![author], config.mw_api()).await;
         Ok(true)
     }
 
@@ -185,7 +167,7 @@ impl SourceMDbot {
                 )
                 .await
                 .map(|_x| true)
-                .ok_or(anyhow!("Can't update {}", &command.identifier));
+                .ok_or(anyhow!("Can't update {}", command.identifier));
         }
 
         // Others: regex-recognised formats
@@ -224,7 +206,7 @@ impl SourceMDbot {
                     command.q = er.q().to_string();
                 }
                 Ok(true)
-            }
+            },
             None => Ok(false),
         }
     }
@@ -239,10 +221,7 @@ impl SourceMDbot {
             .read()
             .await
             .set_command_status(command, status, message.map(|s| s.to_string()))
-            .ok_or(anyhow!(
-                "Can't config.set_command_status for batch #{}",
-                self.batch_id
-            ))?;
+            .ok_or(anyhow!("Can't config.set_command_status for batch #{}", self.batch_id))?;
         Ok(())
     }
 

--- a/src/sourcemd_command.rs
+++ b/src/sourcemd_command.rs
@@ -21,7 +21,7 @@ impl FromStr for SourceMDcommandMode {
             "ADD_AUTHOR_TO_PUBLICATION" => Ok(SourceMDcommandMode::AddAutthorToPublication),
             "ADD_METADATA_FROM_ORCID_TO_AUTHOR" => {
                 Ok(SourceMDcommandMode::AddOrcidMetadataToAuthor)
-            }
+            },
             "EDIT_PAPER_FOR_ORCID_AUTHOR" => Ok(SourceMDcommandMode::EditPaperForOrcidAuthor),
             "CREATE_BOOK_FROM_ISBN" => Ok(SourceMDcommandMode::CreateBookFromIsbn),
             _ => Err(format!("Invalid command: {s}")),
@@ -31,19 +31,14 @@ impl FromStr for SourceMDcommandMode {
 
 impl std::fmt::Display for SourceMDcommandMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                SourceMDcommandMode::Dummy => "DUMMY",
-                SourceMDcommandMode::CreatePaperById => "CREATE_PAPER_BY_ID",
-                SourceMDcommandMode::AddAutthorToPublication => "ADD_AUTHOR_TO_PUBLICATION",
-                SourceMDcommandMode::AddOrcidMetadataToAuthor =>
-                    "ADD_METADATA_FROM_ORCID_TO_AUTHOR",
-                SourceMDcommandMode::EditPaperForOrcidAuthor => "EDIT_PAPER_FOR_ORCID_AUTHOR",
-                SourceMDcommandMode::CreateBookFromIsbn => "CREATE_BOOK_FROM_ISBN",
-            }
-        )
+        write!(f, "{}", match self {
+            SourceMDcommandMode::Dummy => "DUMMY",
+            SourceMDcommandMode::CreatePaperById => "CREATE_PAPER_BY_ID",
+            SourceMDcommandMode::AddAutthorToPublication => "ADD_AUTHOR_TO_PUBLICATION",
+            SourceMDcommandMode::AddOrcidMetadataToAuthor => "ADD_METADATA_FROM_ORCID_TO_AUTHOR",
+            SourceMDcommandMode::EditPaperForOrcidAuthor => "EDIT_PAPER_FOR_ORCID_AUTHOR",
+            SourceMDcommandMode::CreateBookFromIsbn => "CREATE_BOOK_FROM_ISBN",
+        })
     }
 }
 
@@ -108,7 +103,7 @@ impl SourceMDcommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    //use wikibase::mediawiki::api::Api;
+    // use wikibase::mediawiki::api::Api;
 
     #[test]
     fn test_new_dummy() {
@@ -136,8 +131,6 @@ mod tests {
         assert_eq!(SourceMDcommand::rowvalue_as_string(&v), "abc");
     }
 
-    /*
-    TODO:
-    pub fn new_from_row(row: my::Row) -> Self {
-    */
+    // TODO:
+    // pub fn new_from_row(row: my::Row) -> Self {
 }

--- a/src/sourcemd_config.rs
+++ b/src/sourcemd_config.rs
@@ -1,13 +1,15 @@
-use crate::sourcemd_command::SourceMDcommand;
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use chrono::prelude::*;
 use config::{Config, File};
 use dashmap::DashSet;
 use mysql as my;
 use serde_json::Value;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 use wikibase::mediawiki::api::Api;
+
+use crate::sourcemd_command::SourceMDcommand;
 
 #[derive(Debug, Clone)]
 pub struct SourceMD {
@@ -55,10 +57,7 @@ impl SourceMD {
     pub async fn set_batch_running(&self, batch_id: i64) {
         println!("set_batch_running: Starting batch #{}", batch_id);
         self.running_batch_ids.insert(batch_id);
-        println!(
-            "Currently {} bots running",
-            self.number_of_bots_running().await
-        );
+        println!("Currently {} bots running", self.number_of_bots_running().await);
     }
 
     pub async fn number_of_bots_running(&self) -> usize {
@@ -74,7 +73,8 @@ impl SourceMD {
         let pool = self.pool.as_ref()?;
 
         let sql: String = r#"SELECT * FROM batch WHERE `status` ='TODO' AND NOT EXISTS (SELECT * FROM command WHERE batch_id=batch.id AND `status` IN ("RUNNING","TODO") AND `mode` NOT IN ("CREATE_PAPER_BY_ID","ADD_AUTHOR_TO_PUBLICATION")) ORDER BY `last_action`"#.into();
-        //let sql: String = "SELECT * FROM batch WHERE id=8117".into(); // TESTING (also 551)
+        // let sql: String = "SELECT * FROM batch WHERE id=8117".into(); // TESTING
+        // (also 551)
         for row in pool.prep_exec(sql, ()).ok()? {
             let row = row.ok()?;
             let id = match &row["id"] {
@@ -95,10 +95,7 @@ impl SourceMD {
         {
             self.running_batch_ids.remove(&batch_id);
         }
-        println!(
-            "Currently {} bots running",
-            self.number_of_bots_running().await
-        );
+        println!("Currently {} bots running", self.number_of_bots_running().await);
         Some(())
     }
 
@@ -116,7 +113,7 @@ impl SourceMD {
             batch_id
         );
         let mut result = pool.prep_exec(sql, ())?;
-        /* trunk-ignore(clippy/never_loop) */
+        // trunk-ignore(clippy/never_loop)
         if result.next().is_some() {
             return Err(anyhow!(
                 "QuickStatementsConfig::check_batch_not_stopped: batch #{} is not RUNNING or TODO",
@@ -131,21 +128,17 @@ impl SourceMD {
         // TODO stats
         pool.prep_exec(
             r#"UPDATE `batch` SET `status`=?,`last_action`=? WHERE id=?"#,
-            (
-                my::Value::from(status),
-                my::Value::from(self.timestamp()),
-                my::Value::Int(batch_id),
-            ),
+            (my::Value::from(status), my::Value::from(self.timestamp()), my::Value::Int(batch_id)),
         )
         .ok()?;
         self.update_batch_stats(batch_id, pool)
-        //self.deactivate_batch_run(batch_id)
+        // self.deactivate_batch_run(batch_id)
     }
 
     pub fn get_next_command(&self, batch_id: i64) -> Option<SourceMDcommand> {
         let pool = self.pool.as_ref()?;
         let sql = r#"SELECT * FROM command FORCE INDEX (batch_id_4) WHERE `batch_id`=? AND `status`='TODO' ORDER BY `serial_number` LIMIT 1"#;
-        /* trunk-ignore(clippy/never_loop) */
+        // trunk-ignore(clippy/never_loop)
         if let Some(row) = (pool.prep_exec(sql, (my::Value::Int(batch_id),)).ok()?).next() {
             let row = row.ok()?;
             return SourceMDcommand::new_from_row(row);
@@ -195,10 +188,7 @@ impl SourceMD {
         }
         pool.prep_exec(
             r#"UPDATE `batch` SET `overview`=? WHERE `id`=?"#,
-            (
-                my::Value::from(format!("{}", &j)),
-                my::Value::from(batch_id),
-            ),
+            (my::Value::from(format!("{}", j)), my::Value::from(batch_id)),
         )
         .ok()?;
         Some(())
@@ -213,9 +203,8 @@ impl SourceMD {
             .unwrap_or_else(|_| panic!("Replica file '{}' can't be opened", ini_file));
         self.params["mysql"]["user"] =
             json!(settings.get_string("client.user").expect("No client.name"));
-        self.params["mysql"]["pass"] = json!(settings
-            .get_string("client.password")
-            .expect("No client.password"));
+        self.params["mysql"]["pass"] =
+            json!(settings.get_string("client.password").expect("No client.password"));
         self.params["mysql"]["schema"] = json!("s52680__sourcemd_batches_p");
 
         // On Labs
@@ -242,18 +231,15 @@ impl SourceMD {
             None => {
                 println!("{settings:?}");
                 panic!("Can't establish DB connection!");
-            }
+            },
         };
-        pool.prep_exec(
-            r#"UPDATE `batch` SET `status`='TODO' WHERE status='RUNNING'"#,
-            (),
-        )
-        .expect("SourceMD::init: Resetting old running batches to TODO has failed");
+        pool.prep_exec(r#"UPDATE `batch` SET `status`='TODO' WHERE status='RUNNING'"#, ())
+            .expect("SourceMD::init: Resetting old running batches to TODO has failed");
     }
 
     fn create_mysql_pool(&mut self) {
         let mut builder = my::OptsBuilder::new();
-        //println!("{}", &self.params);
+        // println!("{}", &self.params);
         builder
             .ip_or_hostname(self.params["mysql"]["host"].as_str())
             .db_name(self.params["mysql"]["schema"].as_str())
@@ -270,21 +256,19 @@ impl SourceMD {
     pub async fn create_mw_api(ini_file: &str) -> Result<Api> {
         let mut mw_api = Api::new("https://www.wikidata.org/w/api.php").await?;
         // File::with_name(..) is shorthand for File::from(Path::new(..))
-        let settings = Config::builder()
-            .add_source(File::with_name(ini_file))
-            .build()?;
+        let settings = Config::builder().add_source(File::with_name(ini_file)).build()?;
         match settings.get_string("user.token") {
             Ok(token) => {
                 // Use OAuth2 token
                 mw_api.set_oauth2(&token);
-            }
+            },
             Err(_) => {
                 // Use username/password login
                 let lgname = settings.get_string("user.user")?;
                 let lgpass = settings.get_string("user.pass")?;
                 println!("LOGIN {lgname}/{lgpass}");
                 mw_api.login(lgname, lgpass).await?;
-            }
+            },
         }
         Ok(mw_api)
     }

--- a/src/wikidata_interaction.rs
+++ b/src/wikidata_interaction.rs
@@ -1,11 +1,9 @@
+use std::{collections::HashMap, sync::Arc};
+
 use anyhow::Result;
 use async_trait::async_trait;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::RwLock;
-use wikibase::entity_diff::*;
-use wikibase::mediawiki::api::Api;
-use wikibase::*;
+use wikibase::{entity_diff::*, mediawiki::api::Api, *};
 
 #[async_trait]
 pub trait WikidataInteraction {

--- a/src/wikidata_papers.rs
+++ b/src/wikidata_papers.rs
@@ -1,17 +1,22 @@
-use self::identifiers::GenericWorkIdentifier;
-use self::identifiers::GenericWorkType;
-use self::wikidata_interaction::WikidataInteraction;
-use crate::generic_author_info::GenericAuthorInfo;
-use crate::scientific_publication_adapter::ScientificPublicationAdapter;
-use crate::wikidata_string_cache::WikidataStringCache;
-use crate::*;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
 use anyhow::Result;
 use rayon::prelude::*;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 use wikibase::mediawiki::api::Api;
+
+use self::{
+    identifiers::{GenericWorkIdentifier, GenericWorkType},
+    wikidata_interaction::WikidataInteraction,
+};
+use crate::{
+    generic_author_info::GenericAuthorInfo,
+    scientific_publication_adapter::ScientificPublicationAdapter,
+    wikidata_string_cache::WikidataStringCache, *,
+};
 
 pub type Spas = Box<dyn ScientificPublicationAdapter + Sync>;
 
@@ -191,8 +196,8 @@ impl WikidataPapers {
         for author in authors2.iter() {
             match author.find_best_match(authors) {
                 Some((candidate, _points)) => match authors[candidate].merge_from(author) {
-                    Ok(_) => {}
-                    Err(e) => eprintln!("{:?}: {}", &author, e),
+                    Ok(_) => {},
+                    Err(e) => eprintln!("{:?}: {}", author, e),
                 },
                 None => {
                     // Only add if there's truly no overlap with any existing author.
@@ -200,7 +205,7 @@ impl WikidataPapers {
                     if !author.has_partial_match(authors) {
                         authors.push(author.clone());
                     }
-                }
+                },
             }
         }
     }
@@ -213,13 +218,11 @@ impl WikidataPapers {
     ) -> Result<()> {
         let mut authors: Vec<GenericAuthorInfo> = vec![];
         for adapter_id in 0..self.adapters.len() {
-            let publication_id = match self.adapters[adapter_id]
-                .publication_id_from_item(item)
-                .await
-            {
-                Some(id) => id,
-                _ => continue,
-            };
+            let publication_id =
+                match self.adapters[adapter_id].publication_id_from_item(item).await {
+                    Some(id) => id,
+                    _ => continue,
+                };
 
             let adapter = &mut self.adapters[adapter_id];
             adapter2work_id.insert(adapter_id, publication_id.clone());
@@ -230,9 +233,7 @@ impl WikidataPapers {
                     // self.cache.clone(),
                 )
                 .await;
-            adapter
-                .update_statements_for_publication_id(&publication_id, item)
-                .await;
+            adapter.update_statements_for_publication_id(&publication_id, item).await;
 
             // Authors
             let authors2 = adapter.get_author_list(&publication_id).await;
@@ -279,10 +280,8 @@ impl WikidataPapers {
         authors: &Vec<GenericAuthorInfo>,
         mw_api: Arc<RwLock<Api>>,
     ) {
-        let qs: Vec<String> = authors
-            .iter()
-            .filter_map(|a| a.wikidata_item().map(str::to_string))
-            .collect();
+        let qs: Vec<String> =
+            authors.iter().filter_map(|a| a.wikidata_item().map(str::to_string)).collect();
         if qs.is_empty() {
             return;
         }
@@ -294,9 +293,7 @@ impl WikidataPapers {
         drop(api);
 
         for author in authors {
-            author
-                .update_author_item(&mut self.entities, mw_api.clone())
-                .await;
+            author.update_author_item(&mut self.entities, mw_api.clone()).await;
         }
     }
 
@@ -337,8 +334,7 @@ impl WikidataPapers {
             true => vec![],
             false => self.get_items_for_ids(ids).await,
         };
-        self.create_or_update_item_from_items(mw_api, ids, &items)
-            .await
+        self.create_or_update_item_from_items(mw_api, ids, &items).await
     }
 
     pub async fn create_or_update_item_from_q(
@@ -347,8 +343,7 @@ impl WikidataPapers {
         q: &str,
     ) -> Option<EditResult> {
         let items = vec![q.to_owned()];
-        self.create_or_update_item_from_items(mw_api, &vec![], &items)
-            .await
+        self.create_or_update_item_from_items(mw_api, &vec![], &items).await
     }
 
     fn new_publication_item(&self) -> Entity {
@@ -366,15 +361,10 @@ impl WikidataPapers {
         match items.first() {
             Some(q) => {
                 let api = mw_api.read().await;
-                item = self
-                    .entities
-                    .load_entity(&api, q.clone())
-                    .await
-                    .ok()?
-                    .to_owned();
+                item = self.entities.load_entity(&api, q.clone()).await.ok()?.to_owned();
                 drop(api);
                 original_item = item.clone();
-            }
+            },
             None => item = self.new_publication_item(),
         }
 
@@ -387,7 +377,7 @@ impl WikidataPapers {
 
         // Paranoia
         if item.claims().len() < 4 {
-            println!("Skipping {:?}", &ids);
+            println!("Skipping {:?}", ids);
             return None;
         }
 
@@ -405,20 +395,15 @@ impl WikidataPapers {
         params.aliases.add = EntityDiffParamState::All;
         params.claims.add = EntityDiffParamState::All;
         params.claims.remove = EntityDiffParamState::some(&vec!["P2093"]);
-        params.references.list = vec![(
-            EntityDiffParamState::All,
-            EntityDiffParamState::except(&vec!["P813"]),
-        )];
+        params.references.list =
+            vec![(EntityDiffParamState::All, EntityDiffParamState::except(&vec!["P813"]))];
         let mut diff = EntityDiff::new(&original_item, &item, &params);
         diff.set_edit_summary(self.edit_summary.to_owned());
 
         if diff.is_empty() {
             return match original_item.id().as_str() {
                 "" => None,
-                id => Some(EditResult {
-                    q: id.to_string(),
-                    edited: false,
-                }),
+                id => Some(EditResult { q: id.to_string(), edited: false }),
             };
         }
 
@@ -429,10 +414,7 @@ impl WikidataPapers {
             let mut api = mw_api.write().await;
             let new_json = diff.apply_diff(&mut api, &diff).await.ok()?;
             let q = EntityDiff::get_entity_id(&new_json)?;
-            Some(EditResult {
-                q: q.to_string(),
-                edited: true,
-            })
+            Some(EditResult { q: q.to_string(), edited: true })
         }
     }
 
@@ -441,19 +423,17 @@ impl WikidataPapers {
         original_ids: &[GenericWorkIdentifier],
     ) -> Vec<GenericWorkIdentifier> {
         let mut ids: HashSet<GenericWorkIdentifier> = HashSet::new();
-        original_ids
-            .iter()
-            .filter(|id| id.is_legit())
-            .for_each(|id| {
-                ids.insert(id.to_owned());
-            });
+        original_ids.iter().filter(|id| id.is_legit()).for_each(|id| {
+            ids.insert(id.to_owned());
+        });
         loop {
             let last_id_size = ids.len();
             for adapter_id in 0..self.adapters.len() {
                 let adapter = &mut self.adapters[adapter_id];
-                // TODO: CPU work — par_iter blocks the async runtime thread; consider spawn_blocking
+                // TODO: CPU work — par_iter blocks the async runtime thread; consider
+                // spawn_blocking
                 let vids: Vec<GenericWorkIdentifier> = ids.par_iter().cloned().collect();
-                //println!("Adapter {}", adapter.name());
+                // println!("Adapter {}", adapter.name());
                 adapter
                     .get_identifier_list(&vids)
                     .await
@@ -467,7 +447,8 @@ impl WikidataPapers {
                 break;
             }
         }
-        // TODO: CPU work — par_iter blocks the async runtime thread; consider spawn_blocking
+        // TODO: CPU work — par_iter blocks the async runtime thread; consider
+        // spawn_blocking
         ids.par_iter().filter(|id| id.is_legit()).cloned().collect()
     }
 
@@ -500,12 +481,10 @@ impl WikidataPapers {
         item.claims()
             .par_iter()
             .filter(|statement| statement.property() == "P50")
-            .filter_map(
-                |statement| match statement.main_snak().data_value().as_ref()?.value() {
-                    Value::Entity(entity) => Some(entity.id().to_string()),
-                    _ => None,
-                },
-            )
+            .filter_map(|statement| match statement.main_snak().data_value().as_ref()?.value() {
+                Value::Entity(entity) => Some(entity.id().to_string()),
+                _ => None,
+            })
             .collect()
     }
 
@@ -515,14 +494,11 @@ impl WikidataPapers {
         // Preserve qualifiers from the existing P2093 statement (e.g. P1545 ordinal).
         // P2093 qualifiers take precedence over the generated P50's qualifiers,
         // because the P2093 reflects what's already on Wikidata.
-        let p2093_properties: HashSet<String> = p2093_statement
-            .qualifiers()
-            .iter()
-            .map(|q| q.property().to_string())
-            .collect();
-        // Build merged qualifiers: start with P2093's, then add non-conflicting P50 ones.
-        // Always exclude P1932 from the P50's qualifiers — we'll add the correct one
-        // from the P2093's actual name string below.
+        let p2093_properties: HashSet<String> =
+            p2093_statement.qualifiers().iter().map(|q| q.property().to_string()).collect();
+        // Build merged qualifiers: start with P2093's, then add non-conflicting P50
+        // ones. Always exclude P1932 from the P50's qualifiers — we'll add the
+        // correct one from the P2093's actual name string below.
         let mut merged_qualifiers: Vec<Snak> = p2093_statement.qualifiers().to_vec();
         for q in p50_statement.qualifiers() {
             if q.property() != "P1932" && !p2093_properties.contains(q.property()) {
@@ -578,10 +554,13 @@ mod tests {
     }
 
     /// Helper: create a WikidataPapers with no adapters (for unit testing).
-    /// Uses a wiremock server for the MediaWiki API so no real network calls are made.
+    /// Uses a wiremock server for the MediaWiki API so no real network calls
+    /// are made.
     async fn make_wdp() -> WikidataPapers {
-        use wiremock::matchers::{method, query_param};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use wiremock::{
+            matchers::{method, query_param},
+            Mock, MockServer, ResponseTemplate,
+        };
 
         const SITEINFO: &str = include_str!("../test_data/api_siteinfo.json");
 
@@ -597,9 +576,7 @@ mod tests {
             .await;
 
         let mw_api = Arc::new(tokio::sync::RwLock::new(
-            wikibase::mediawiki::api::Api::new(&mock_server.uri())
-                .await
-                .unwrap(),
+            wikibase::mediawiki::api::Api::new(&mock_server.uri()).await.unwrap(),
         ));
         let cache = Arc::new(WikidataStringCache::new(mw_api));
         // mock_server is intentionally dropped here: the tests below do not
@@ -649,7 +626,8 @@ mod tests {
         let claim = &item.claims()[0];
         assert_eq!(claim.main_snak().property(), "P50", "Should be P50");
 
-        // The ordinal should be #42 (from the original P2093), NOT #44 (from the adapter)
+        // The ordinal should be #42 (from the original P2093), NOT #44 (from the
+        // adapter)
         let ordinal = get_ordinal(claim);
         assert_eq!(
             ordinal,
@@ -743,7 +721,8 @@ mod tests {
         get_string_qualifier(statement, "P1932")
     }
 
-    // === Bug reproduction: P1932 uses adapter name instead of P2093 name (issue #5) ===
+    // === Bug reproduction: P1932 uses adapter name instead of P2093 name (issue
+    // #5) ===
     //
     // When converting P2093 "José García" to P50, the P1932 ("object named as")
     // qualifier should preserve the original P2093 name, not the adapter's
@@ -778,7 +757,8 @@ mod tests {
         );
     }
 
-    // Same issue but with a completely different adapter name (e.g. transliteration)
+    // Same issue but with a completely different adapter name (e.g.
+    // transliteration)
     #[tokio::test]
     async fn update_author_statements_p1932_preserves_original_name_transliteration() {
         let wdp = make_wdp().await;

--- a/src/wikidata_string_cache.rs
+++ b/src/wikidata_string_cache.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::SystemTime;
+use std::{collections::HashMap, sync::Arc, time::SystemTime};
+
 use wikibase::mediawiki::api::Api;
 
 use crate::wikidata_interaction::WikidataInteraction;
@@ -15,10 +14,7 @@ struct WikidataStringValue {
 
 impl WikidataStringValue {
     pub fn new(key: Option<String>) -> Self {
-        Self {
-            key,
-            timestamp: SystemTime::now(),
-        }
+        Self { key, timestamp: SystemTime::now() }
     }
 
     pub fn key(&mut self) -> Option<String> {
@@ -64,7 +60,7 @@ impl WikidataStringCache {
             Some(ret) => {
                 ret.update_timestamp();
                 (ret.key(), false)
-            }
+            },
             None => (None, true),
         };
         if do_search {
@@ -136,10 +132,7 @@ impl WikidataStringCache {
     /// Creates a new cache for a specific property
     async fn ensure_property(&self, property: &str) {
         if !self.has_property(property).await {
-            self.cache
-                .write()
-                .await
-                .insert(property.to_string(), HashMap::new());
+            self.cache.write().await.insert(property.to_string(), HashMap::new());
         }
     }
 
@@ -149,10 +142,7 @@ impl WikidataStringCache {
     /// Stores/returns the first result, if multiple found
     async fn search(&self, property: &str, key: &str) -> Option<String> {
         let ret = match self
-            .search_wikibase(
-                &format!("haswbstatement:{}={}", property, key),
-                self.mw_api.clone(),
-            )
+            .search_wikibase(&format!("haswbstatement:{}={}", property, key), self.mw_api.clone())
             .await
         {
             Ok(items) => items.first().map(|s| s.to_string()), // Picking first one, if several
@@ -165,20 +155,24 @@ impl WikidataStringCache {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::thread;
-    use std::time::Duration;
+    use std::{thread, time::Duration};
+
     use wikibase::mediawiki::api::Api;
-    use wiremock::matchers::{method, query_param};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{
+        matchers::{method, query_param},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    use super::*;
 
     const SITEINFO: &str = include_str!("../test_data/api_siteinfo.json");
     const SEARCH_Q46664291: &str = include_str!("../test_data/search_found_q46664291.json");
     const SEARCH_Q15757256: &str = include_str!("../test_data/search_found_q15757256.json");
     const SEARCH_EMPTY: &str = include_str!("../test_data/search_empty.json");
 
-    /// Starts a wiremock server with the MediaWiki siteinfo response pre-registered.
-    /// The returned server must be kept alive for the duration of the test.
+    /// Starts a wiremock server with the MediaWiki siteinfo response
+    /// pre-registered. The returned server must be kept alive for the
+    /// duration of the test.
     async fn start_mock_server() -> MockServer {
         let mock_server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -208,9 +202,7 @@ mod tests {
 
     /// Creates an `Api` connected to the mock server.
     async fn mock_api(mock_server: &MockServer) -> Arc<tokio::sync::RwLock<Api>> {
-        Arc::new(tokio::sync::RwLock::new(
-            Api::new(&mock_server.uri()).await.unwrap(),
-        ))
+        Arc::new(tokio::sync::RwLock::new(Api::new(&mock_server.uri()).await.unwrap()))
     }
 
     #[test]
@@ -250,53 +242,23 @@ mod tests {
     #[tokio::test]
     async fn search() {
         let mock_server = start_mock_server().await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P698=16116339",
-            SEARCH_Q46664291,
-        )
-        .await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P698=not_a_valid_id",
-            SEARCH_EMPTY,
-        )
-        .await;
+        add_search_mock(&mock_server, "haswbstatement:P698=16116339", SEARCH_Q46664291).await;
+        add_search_mock(&mock_server, "haswbstatement:P698=not_a_valid_id", SEARCH_EMPTY).await;
         let wsc = WikidataStringCache::new(mock_api(&mock_server).await);
-        assert_eq!(
-            wsc.search("P698", "16116339").await,
-            Some("Q46664291".to_string())
-        );
+        assert_eq!(wsc.search("P698", "16116339").await, Some("Q46664291".to_string()));
         assert_eq!(wsc.search("P698", "not_a_valid_id").await, None);
     }
 
     #[tokio::test]
     async fn get_set() {
         let mock_server = start_mock_server().await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P698=16116339",
-            SEARCH_Q46664291,
-        )
-        .await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P698=not_a_valid_id",
-            SEARCH_EMPTY,
-        )
-        .await;
+        add_search_mock(&mock_server, "haswbstatement:P698=16116339", SEARCH_Q46664291).await;
+        add_search_mock(&mock_server, "haswbstatement:P698=not_a_valid_id", SEARCH_EMPTY).await;
         let wsc = WikidataStringCache::new(mock_api(&mock_server).await);
-        assert_eq!(
-            wsc.get("P698", "16116339").await,
-            Some("Q46664291".to_string())
-        );
+        assert_eq!(wsc.get("P698", "16116339").await, Some("Q46664291".to_string()));
         assert_eq!(wsc.get("P698", "not_a_valid_id").await, None);
-        wsc.set("P698", "16116339", Some("foobar".to_string()))
-            .await;
-        assert_eq!(
-            wsc.get("P698", "16116339").await,
-            Some("foobar".to_string())
-        );
+        wsc.set("P698", "16116339", Some("foobar".to_string())).await;
+        assert_eq!(wsc.get("P698", "16116339").await, Some("foobar".to_string()));
         wsc.set("P698", "16116339", None).await;
         assert_eq!(wsc.get("P698", "16116339").await, None);
     }
@@ -304,18 +266,8 @@ mod tests {
     #[tokio::test]
     async fn issn2q() {
         let mock_server = start_mock_server().await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P236=1351-5101",
-            SEARCH_Q15757256,
-        )
-        .await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P236=nope-di-dope",
-            SEARCH_EMPTY,
-        )
-        .await;
+        add_search_mock(&mock_server, "haswbstatement:P236=1351-5101", SEARCH_Q15757256).await;
+        add_search_mock(&mock_server, "haswbstatement:P236=nope-di-dope", SEARCH_EMPTY).await;
         let wsc = WikidataStringCache::new(mock_api(&mock_server).await);
         assert_eq!(wsc.issn2q("1351-5101").await, Some("Q15757256".to_string()));
         assert_eq!(wsc.issn2q("nope-di-dope").await, None);
@@ -326,12 +278,7 @@ mod tests {
         let mock_server = start_mock_server().await;
         let mut wsc = WikidataStringCache::new(mock_api(&mock_server).await);
         for num in 1..10 {
-            wsc.set(
-                "P123",
-                &format!("Key #{}", num),
-                Some(format!("Value #{}", num)),
-            )
-            .await;
+            wsc.set("P123", &format!("Key #{}", num), Some(format!("Value #{}", num))).await;
             thread::sleep(Duration::from_millis(10));
         }
         wsc.max_cache_size_per_property = 5;
@@ -345,12 +292,7 @@ mod tests {
         let mut wsc = WikidataStringCache::new(mock_api(&mock_server).await);
         assert!(!wsc.property_needs_pruning("P123").await);
         for num in 1..10 {
-            wsc.set(
-                "P123",
-                &format!("Key #{}", num),
-                Some(format!("Value #{}", num)),
-            )
-            .await;
+            wsc.set("P123", &format!("Key #{}", num), Some(format!("Value #{}", num))).await;
         }
         wsc.max_cache_size_per_property = 5;
         assert!(wsc.property_needs_pruning("P123").await);
@@ -379,24 +321,12 @@ mod tests {
     #[tokio::test]
     async fn search_wikibase() {
         let mock_server = start_mock_server().await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P698=16116339",
-            SEARCH_Q46664291,
-        )
-        .await;
-        add_search_mock(
-            &mock_server,
-            "haswbstatement:P698=not_a_valid_id",
-            SEARCH_EMPTY,
-        )
-        .await;
+        add_search_mock(&mock_server, "haswbstatement:P698=16116339", SEARCH_Q46664291).await;
+        add_search_mock(&mock_server, "haswbstatement:P698=not_a_valid_id", SEARCH_EMPTY).await;
         let api = mock_api(&mock_server).await;
         let wsc = WikidataStringCache::new(api.clone());
         assert_eq!(
-            wsc.search_wikibase("haswbstatement:P698=16116339", api.clone())
-                .await
-                .unwrap(),
+            wsc.search_wikibase("haswbstatement:P698=16116339", api.clone()).await.unwrap(),
             vec!["Q46664291".to_string()]
         );
         assert_eq!(


### PR DESCRIPTION
This PR was just running clippy in pedantic mode, and then removing any unnecessary `&` and for the `get_author_name_string` I had to rewrite it as the original was hiding an implicit clone and clippy's fix was pointing that. replaced the string concatenation with a use of the `format!` macro. I also used `fmt` to group imports for each module, as many could be combined e.g.
```rust
Papers::...;
Papers::...;
Papers::...;
```
becomes 
```rust
Papers::{...};


All tests are passing. 